### PR TITLE
Revert "feat: implement EXIF-based folder organization with comprehen…

### DIFF
--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,241 +10,178 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type testFile struct {
-	name     string
-	isZombie bool // true if it's a zombie edit file (no corresponding raw)
-	inSubdir bool // true if file should be in subdirectory
-}
-
 func TestDeleteZombieEditFiles(t *testing.T) {
+	t.Run("deletes zombie edit files when no corresponding raw file exists", func(t *testing.T) {
+		dirTest := t.TempDir()
 
-	tests := []struct {
-		name                string
-		files               []testFile
-		editExtension       string
-		rawExtensions       []string
-		recursive           bool
-		expectedDeleteCount int
-		expectedRemaining   []string // files that should remain after cleanup
-		shouldError         bool
-		description         string
-	}{
-		{
-			name: "deletes zombie edit files when no corresponding raw file exists",
-			files: []testFile{
-				{name: "photo1.xmp", isZombie: true},
-				{name: "photo2.xmp", isZombie: true},
-				{name: "photo3.xmp", isZombie: true},
-			},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw"},
-			recursive:           false,
-			expectedDeleteCount: 3,
-			expectedRemaining:   []string{},
-			description:         "All XMP files without corresponding RAW files should be deleted",
-		},
-		{
-			name: "keeps edit files when corresponding raw file exists",
-			files: []testFile{
-				{name: "photo1.xmp", isZombie: false},
-				{name: "photo1.arw", isZombie: false},
-				{name: "photo2.xmp", isZombie: false},
-				{name: "photo2.raw", isZombie: false},
-			},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw"},
-			recursive:           false,
-			expectedDeleteCount: 0,
-			expectedRemaining:   []string{"photo1.arw", "photo1.xmp", "photo2.raw", "photo2.xmp"},
-			description:         "XMP files with corresponding RAW files should be kept",
-		},
-		{
-			name: "mixed scenario - keeps valid and deletes zombies",
-			files: []testFile{
-				{name: "valid.xmp", isZombie: false},
-				{name: "valid.arw", isZombie: false},
-				{name: "zombie1.xmp", isZombie: true},
-				{name: "zombie2.xmp", isZombie: true},
-			},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw"},
-			recursive:           false,
-			expectedDeleteCount: 2,
-			expectedRemaining:   []string{"valid.arw", "valid.xmp"},
-			description:         "Should delete only zombie XMP files and keep valid pairs",
-		},
-		{
-			name: "ignores non-edit file extensions",
-			files: []testFile{
-				{name: "photo.jpg", isZombie: false},
-				{name: "photo.png", isZombie: false},
-				{name: "document.txt", isZombie: false},
-			},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw"},
-			recursive:           false,
-			expectedDeleteCount: 0,
-			expectedRemaining:   []string{"document.txt", "photo.jpg", "photo.png"},
-			description:         "Non-XMP files should be ignored and left untouched",
-		},
-		{
-			name:                "handles empty directory gracefully",
-			files:               []testFile{},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw"},
-			recursive:           false,
-			expectedDeleteCount: 0,
-			expectedRemaining:   []string{},
-			description:         "Empty directory should result in zero deletions",
-		},
-		{
-			name: "recursive mode processes subdirectories",
-			files: []testFile{
-				{name: "root_zombie.xmp", isZombie: true, inSubdir: false},
-				{name: "sub_zombie.xmp", isZombie: true, inSubdir: true},
-				{name: "valid.xmp", isZombie: false, inSubdir: true},
-				{name: "valid.arw", isZombie: false, inSubdir: true},
-			},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw"},
-			recursive:           true,
-			expectedDeleteCount: 2,
-			expectedRemaining:   []string{"valid.arw", "valid.xmp"}, // in subdir
-			description:         "Recursive mode should delete zombies in root and subdirectories",
-		},
-		{
-			name: "non-recursive mode skips subdirectories",
-			files: []testFile{
-				{name: "root_zombie.xmp", isZombie: true, inSubdir: false},
-				{name: "sub_zombie.xmp", isZombie: true, inSubdir: true},
-			},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw"},
-			recursive:           false,
-			expectedDeleteCount: 1,
-			expectedRemaining:   []string{"sub_zombie.xmp"}, // should remain in subdir
-			description:         "Non-recursive mode should only process root directory",
-		},
-		{
-			name: "handles multiple raw extensions correctly",
-			files: []testFile{
-				{name: "photo1.xmp", isZombie: false},
-				{name: "photo1.arw", isZombie: false},
-				{name: "photo2.xmp", isZombie: false},
-				{name: "photo2.raw", isZombie: false},
-				{name: "photo3.xmp", isZombie: false},
-				{name: "photo3.dng", isZombie: false},
-				{name: "zombie.xmp", isZombie: true},
-			},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw", "dng"},
-			recursive:           false,
-			expectedDeleteCount: 1,
-			expectedRemaining:   []string{"photo1.arw", "photo1.xmp", "photo2.raw", "photo2.xmp", "photo3.dng", "photo3.xmp"},
-			description:         "Should match XMP files against multiple RAW extensions",
-		},
-		{
-			name: "case insensitive extension matching",
-			files: []testFile{
-				{name: "photo1.XMP", isZombie: false},
-				{name: "photo1.ARW", isZombie: false},
-				{name: "photo2.Xmp", isZombie: false},
-				{name: "photo2.Raw", isZombie: false},
-			},
-			editExtension:       "xmp",
-			rawExtensions:       []string{"arw", "raw"},
-			recursive:           false,
-			expectedDeleteCount: 0,
-			expectedRemaining:   []string{"photo1.ARW", "photo1.XMP", "photo2.Raw", "photo2.Xmp"},
-			description:         "Extension matching should be case-insensitive",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dirTest := t.TempDir()
-			subDir := filepath.Join(dirTest, "subdir")
-
-			// Create subdirectory if needed
-			if hasSubdirFiles(tt.files) {
-				err := os.MkdirAll(subDir, 0755)
-				require.NoError(t, err)
-			}
-
-			// Create test files
-			for _, f := range tt.files {
-				targetDir := dirTest
-				if f.inSubdir {
-					targetDir = subDir
-				}
-				_, err := os.Create(filepath.Join(targetDir, f.name))
-				require.NoError(t, err, "Failed to create test file: %s", f.name)
-			}
-
-			// Execute the function under test
-			count, err := deleteZombieEditFiles(tt.editExtension, dirTest, tt.rawExtensions, tt.recursive)
-
-			// Assertions
-			if tt.shouldError {
-				assert.Error(t, err, tt.description)
-			} else {
-				assert.NoError(t, err, tt.description)
-			}
-
-			assert.Equal(t, tt.expectedDeleteCount, count, "Deleted file count mismatch. %s", tt.description)
-
-			// Verify remaining files
-			var actualRemaining []string
-
-			// Check files in root
-			entries, err := os.ReadDir(dirTest)
+		// Create zombie edit files (no corresponding raw files)
+		for i := range 3 {
+			_, err := os.Create(filepath.Join(dirTest, fmt.Sprintf("photo%d.xmp", i+1)))
 			require.NoError(t, err)
-			for _, entry := range entries {
-				if !entry.IsDir() {
-					actualRemaining = append(actualRemaining, entry.Name())
-				}
-			}
-
-			// For non-recursive mode with subdirectory files, check subdirectory separately
-			if !tt.recursive && hasSubdirFiles(tt.files) {
-				// Check if we expect files to remain in subdirectory
-				entries, err := os.ReadDir(subDir)
-				require.NoError(t, err)
-				for _, entry := range entries {
-					if !entry.IsDir() {
-						actualRemaining = append(actualRemaining, entry.Name())
-					}
-				}
-			} else if tt.recursive && hasSubdirFiles(tt.files) {
-				// For recursive mode, check subdirectory
-				entries, err := os.ReadDir(subDir)
-				require.NoError(t, err)
-				for _, entry := range entries {
-					if !entry.IsDir() {
-						actualRemaining = append(actualRemaining, entry.Name())
-					}
-				}
-			}
-
-			assert.ElementsMatch(t, tt.expectedRemaining, actualRemaining, "Remaining files don't match. %s", tt.description)
-		})
-	}
-
-	// Separate test for non-existent directory (can't use table-driven approach)
-	t.Run("returns error for non-existent directory", func(t *testing.T) {
-		count, err := deleteZombieEditFiles("xmp", "/non/existent/path/12345", []string{"arw", "raw"}, false)
-
-		assert.Error(t, err, "Should return error for non-existent directory")
-		assert.Equal(t, 0, count, "Delete count should be 0 on error")
-	})
-}
-
-// Helper function to check if any files should be in subdirectory
-func hasSubdirFiles(files []testFile) bool {
-	for _, f := range files {
-		if f.inSubdir {
-			return true
 		}
-	}
-	return false
+
+		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 3, count)
+
+		// Verify all zombie files are deleted
+		entries, err := os.ReadDir(dirTest)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(entries))
+	})
+
+	t.Run("keeps edit files when corresponding raw file exists", func(t *testing.T) {
+		dirTest := t.TempDir()
+
+		// Create edit file with corresponding raw file
+		_, err := os.Create(filepath.Join(dirTest, "photo1.xmp"))
+		require.NoError(t, err)
+		_, err = os.Create(filepath.Join(dirTest, "photo1.arw"))
+		require.NoError(t, err)
+
+		// Create another edit file with corresponding raw file (different extension)
+		_, err = os.Create(filepath.Join(dirTest, "photo2.xmp"))
+		require.NoError(t, err)
+		_, err = os.Create(filepath.Join(dirTest, "photo2.raw"))
+		require.NoError(t, err)
+
+		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, count)
+
+		// Verify all files still exist
+		entries, err := os.ReadDir(dirTest)
+		require.NoError(t, err)
+		assert.Equal(t, 4, len(entries))
+	})
+
+	t.Run("mixed scenario with some zombie and some valid edit files", func(t *testing.T) {
+		dirTest := t.TempDir()
+
+		// Create valid edit file (has corresponding raw)
+		_, err := os.Create(filepath.Join(dirTest, "valid.xmp"))
+		require.NoError(t, err)
+		_, err = os.Create(filepath.Join(dirTest, "valid.arw"))
+		require.NoError(t, err)
+
+		// Create zombie edit files (no corresponding raw)
+		_, err = os.Create(filepath.Join(dirTest, "zombie1.xmp"))
+		require.NoError(t, err)
+		_, err = os.Create(filepath.Join(dirTest, "zombie2.xmp"))
+		require.NoError(t, err)
+
+		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, count)
+
+		// Verify valid files still exist and zombies are deleted
+		entries, err := os.ReadDir(dirTest)
+		require.NoError(t, err)
+
+		fileNames := make([]string, len(entries))
+		for i, entry := range entries {
+			fileNames[i] = entry.Name()
+		}
+		assert.ElementsMatch(t, []string{"valid.xmp", "valid.arw"}, fileNames)
+	})
+
+	t.Run("does not delete non-edit files", func(t *testing.T) {
+		dirTest := t.TempDir()
+
+		// Create non-edit files
+		_, err := os.Create(filepath.Join(dirTest, "photo.jpg"))
+		require.NoError(t, err)
+		_, err = os.Create(filepath.Join(dirTest, "photo.png"))
+		require.NoError(t, err)
+
+		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, count)
+
+		// Verify files still exist
+		entries, err := os.ReadDir(dirTest)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(entries))
+	})
+
+	t.Run("handles empty directory", func(t *testing.T) {
+		dirTest := t.TempDir()
+
+		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("returns error for non-existent directory", func(t *testing.T) {
+		count, err := deleteZombieEditFiles("xmp", "/non/existent/path", []string{"arw", "raw"}, false)
+
+		assert.Error(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("recursive mode deletes zombie files in subdirectories", func(t *testing.T) {
+		dirTest := t.TempDir()
+		subDir := filepath.Join(dirTest, "subdir")
+		err := os.MkdirAll(subDir, 0755)
+		require.NoError(t, err)
+
+		// Create zombie edit file in root
+		_, err = os.Create(filepath.Join(dirTest, "root_zombie.xmp"))
+		require.NoError(t, err)
+
+		// Create zombie edit file in subdirectory
+		_, err = os.Create(filepath.Join(subDir, "sub_zombie.xmp"))
+		require.NoError(t, err)
+
+		// Create valid edit file with raw in subdirectory
+		_, err = os.Create(filepath.Join(subDir, "valid.xmp"))
+		require.NoError(t, err)
+		_, err = os.Create(filepath.Join(subDir, "valid.arw"))
+		require.NoError(t, err)
+
+		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, true)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, count) // root_zombie.xmp + sub_zombie.xmp
+
+		// Verify valid files in subdirectory still exist
+		entries, err := os.ReadDir(subDir)
+		require.NoError(t, err)
+		fileNames := make([]string, len(entries))
+		for i, entry := range entries {
+			fileNames[i] = entry.Name()
+		}
+		assert.ElementsMatch(t, []string{"valid.xmp", "valid.arw"}, fileNames)
+	})
+
+	t.Run("non-recursive mode skips subdirectories", func(t *testing.T) {
+		dirTest := t.TempDir()
+		subDir := filepath.Join(dirTest, "subdir")
+		err := os.MkdirAll(subDir, 0755)
+		require.NoError(t, err)
+
+		// Create zombie edit file in root
+		_, err = os.Create(filepath.Join(dirTest, "root_zombie.xmp"))
+		require.NoError(t, err)
+
+		// Create zombie edit file in subdirectory
+		_, err = os.Create(filepath.Join(subDir, "sub_zombie.xmp"))
+		require.NoError(t, err)
+
+		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, count) // only root_zombie.xmp
+
+		// Verify subdirectory file still exists
+		entries, err := os.ReadDir(subDir)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(entries))
+		assert.Equal(t, "sub_zombie.xmp", entries[0].Name())
+	})
 }

--- a/config.go
+++ b/config.go
@@ -5,10 +5,8 @@ const (
 	defaultDirDst     = "D:\\raw"
 	defaultDirDstJPGs = "D:\\jpg"
 
-	defaultFolderCreationThresholdOneDay          = 600
-	defaultFolderCreationThresholdConsecutiveDays = 300
-
-	dateFormat = "200601-02"
+	defaultMinDailyPhotosForDir = 700
+	defaultMinDailyPhotosForEvent = 300
 )
 
 var (

--- a/fileops.go
+++ b/fileops.go
@@ -9,129 +9,57 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
-
-	"github.com/rwcarlsen/goexif/exif"
 )
-
-// fileWithDate represents a file and its EXIF date
-type fileWithDate struct {
-	name string
-	date time.Time
-}
-
-// dateGroup represents files grouped by date
-type dateGroup struct {
-	date  time.Time
-	files []string
-}
 
 // copyFiles copies files with the given extension from srcDir to dstDir.
 // If flagDryRun is true, it counts files without copying.
 // If flagOverwrite is true, it overwrites existing files in dstDir.
 // It returns the number of files copied and any error.
-func copyFiles(srcDir, dstDir, ext string, folderCreationThresholdOneDay, folderCreationThresholdConsecutiveDays int, flagDryRun, flagOverwrite bool) (int, error) {
+func copyFiles(srcDir, dstDir, ext string, flagDryRun, flagOverwrite bool) (int, error) {
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
 		return 0, err
 	}
 
-	// First pass: read all files and extract EXIF dates
-	filesWithDates := make([]fileWithDate, 0)
-
+	var count atomic.Int32
 	var wg sync.WaitGroup
-	for _, entry := range entries {
-		wg.Go(func() {
-			if entry.IsDir() {
-				return
-			}
+	errChan := make(chan fileCopyError, len(entries))
 
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		wg.Go(func() {
 			name := entry.Name()
 			if !strings.EqualFold(filepath.Ext(name), "."+ext) {
 				return
 			}
 
-			filePath := filepath.Join(srcDir, name)
-			file, err := os.Open(filePath)
-			if err != nil {
-				log.Printf("Error opening file %s: %v\n", name, err)
-				return
-			}
+			srcPath := filepath.Join(srcDir, name)
+			dstPath := filepath.Join(dstDir, name)
 
-			exifData, err := exif.Decode(file)
-			file.Close()
-			if err != nil {
-				log.Printf("Error reading EXIF from %s: %v\n", name, err)
-				return
-			}
-
-			date, err := exifData.DateTime()
-			if err != nil {
-				log.Printf("Error getting date from EXIF for %s: %v\n", name, err)
-				return
-			}
-
-			filesWithDates = append(filesWithDates, fileWithDate{name: name, date: date})
-		})
-	}
-	wg.Wait()
-
-	if len(filesWithDates) == 0 {
-		return 0, nil
-	}
-
-	// Group files by date (YYYY-MM-DD)
-	dateGroups := groupFilesByDate(filesWithDates)
-
-	// Detect consecutive days and merge if needed
-	finalGroups := detectConsecutiveDays(dateGroups, folderCreationThresholdOneDay, folderCreationThresholdConsecutiveDays)
-
-	// Copy files concurrently based on groups
-	var count atomic.Int32
-	errsChan := make(chan fileCopyError, len(filesWithDates))
-
-	for _, group := range finalGroups {
-		// Determine the actual destination directory
-		var actualDestDir string
-		if group.destDir == "." {
-			actualDestDir = dstDir
-		} else {
-			actualDestDir = filepath.Join(dstDir, group.destDir)
-			// Create the subdirectory if needed
-			if !flagDryRun {
-				if err := os.MkdirAll(actualDestDir, 0755); err != nil {
-					return int(count.Load()), err
-				}
-			}
-		}
-
-		for _, fileName := range group.files {
-			wg.Go(func() {
-				srcPath := filepath.Join(srcDir, fileName)
-				dstPath := filepath.Join(actualDestDir, fileName)
-
-				if !flagOverwrite {
-					if _, statErr := os.Stat(dstPath); statErr == nil {
-						log.Printf("Skipping copying existing file: %s\n", fileName)
-						return
-					}
-				}
-
-				if flagDryRun {
-					log.Printf("[DryRun] Would copy %s to %s\n", fileName, actualDestDir)
-					count.Add(1)
+			if !flagOverwrite {
+				if _, statErr := os.Stat(dstPath); statErr == nil {
+					log.Printf("Skipping copying existing file: %s\n", name)
 					return
 				}
+			}
 
-				if copyErr := copyFile(srcPath, dstPath); copyErr != nil {
-					errsChan <- fileCopyError{fileName: fileName, err: copyErr}
-					return
-				}
-
-				log.Printf("Copied %s to %s\n", fileName, actualDestDir)
+			if flagDryRun {
+				log.Printf("[DryRun] Would copy %s\n", name)
 				count.Add(1)
-			})
-		}
+				return
+			}
+
+			if copyErr := copyFile(srcPath, dstPath); copyErr != nil {
+				errChan <- fileCopyError{fileName: name, err: copyErr}
+				return
+			}
+
+			log.Printf("Copied %s\n", name)
+			count.Add(1)
+		})
 	}
 
 	wg.Wait()
@@ -139,128 +67,10 @@ func copyFiles(srcDir, dstDir, ext string, folderCreationThresholdOneDay, folder
 
 	var errs error
 	for e := range errsChan {
-		errs = errors.Join(errs, e)
+		err = errors.Join(errs, e)
 	}
 
 	return int(count.Load()), errs
-}
-
-// groupFilesByDate groups files by their date (YYYY-MM-DD)
-func groupFilesByDate(filesWithDates []fileWithDate) []dateGroup {
-	dateMap := make(map[string]*dateGroup)
-
-	for _, fwd := range filesWithDates {
-		dateKey := fwd.date.Format(dateFormat)
-		if group, ok := dateMap[dateKey]; ok {
-			group.files = append(group.files, fwd.name)
-		} else {
-			dateMap[dateKey] = &dateGroup{
-				date:  fwd.date,
-				files: []string{fwd.name},
-			}
-		}
-	}
-
-	groups := make([]dateGroup, 0, len(dateMap))
-	for _, group := range dateMap {
-		groups = append(groups, *group)
-	}
-
-	// Sort groups by date
-	for i := range len(groups) {
-		for j := range len(groups) {
-			if groups[i].date.After(groups[j].date) {
-				groups[i], groups[j] = groups[j], groups[i]
-			}
-		}
-	}
-
-	return groups
-}
-
-// groupWithDestDir represents a group of files with their destination directory
-type groupWithDestDir struct {
-	files   []string
-	destDir string
-}
-
-// detectConsecutiveDays analyzes date groups and creates appropriate folder structure
-func detectConsecutiveDays(dateGroups []dateGroup, thresholdOneDay, thresholdConsecutiveDays int) []groupWithDestDir {
-	result := make([]groupWithDestDir, 0)
-
-	i := 0
-	for i < len(dateGroups) {
-		currentGroup := dateGroups[i]
-		fileCount := len(currentGroup.files)
-
-		// First, check if current day qualifies for consecutive day detection (>= thresholdConsecutiveDays)
-		if fileCount >= thresholdConsecutiveDays {
-			// Look ahead for consecutive days with >= thresholdConsecutiveDays photos per day
-			consecutiveGroups := []dateGroup{currentGroup}
-			j := i + 1
-
-			for j < len(dateGroups) {
-				nextGroup := dateGroups[j]
-				lastGroup := consecutiveGroups[len(consecutiveGroups)-1]
-
-				// Check if dates are consecutive and next day has enough photos
-				if isConsecutiveDay(lastGroup.date, nextGroup.date) && len(nextGroup.files) >= thresholdConsecutiveDays {
-					consecutiveGroups = append(consecutiveGroups, nextGroup)
-					j++
-				} else {
-					break
-				}
-			}
-
-			// If we have 2 or more consecutive days with >= thresholdConsecutiveDays photos each, group them
-			if len(consecutiveGroups) >= 2 {
-				allFiles := make([]string, 0)
-				for _, g := range consecutiveGroups {
-					allFiles = append(allFiles, g.files...)
-				}
-
-				firstDate := consecutiveGroups[0].date
-				lastDate := consecutiveGroups[len(consecutiveGroups)-1].date
-				destDir := firstDate.Format("20060102") + "-" + lastDate.Format("20060102")
-
-				result = append(result, groupWithDestDir{
-					files:   allFiles,
-					destDir: destDir,
-				})
-
-				i = j
-				continue
-			}
-		}
-
-		// If not part of consecutive days, check if it's a high-volume single day
-		if fileCount >= thresholdOneDay {
-			// Single high-volume day, create folder for this day
-			destDir := currentGroup.date.Format("20060102")
-			result = append(result, groupWithDestDir{
-				files:   currentGroup.files,
-				destDir: destDir,
-			})
-			i++
-		} else {
-			// Low-volume day, files go to root destination directory
-			result = append(result, groupWithDestDir{
-				files:   currentGroup.files,
-				destDir: ".",
-			})
-			i++
-		}
-	}
-
-	return result
-}
-
-// isConsecutiveDay checks if date2 is the day after date1
-func isConsecutiveDay(date1, date2 time.Time) bool {
-	nextDay := date1.AddDate(0, 0, 1)
-	y1, m1, d1 := nextDay.Date()
-	y2, m2, d2 := date2.Date()
-	return y1 == y2 && m1 == m2 && d1 == d2
 }
 
 // copyFile copies a single file from src to dst.
@@ -296,12 +106,11 @@ func removeFiles(dir string) (int, error) {
 		}
 
 		path := filepath.Join(dir, entry.Name())
-		if err = os.Remove(path); err != nil {
+		if err := os.Remove(path); err != nil {
 			return count, err
 		}
 		log.Printf("Removed %s\n", entry.Name())
 		count++
 	}
-
 	return count, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module clean-sd-card
 
 go 1.25.0
 
-require (
-	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
-	github.com/stretchr/testify v1.11.1
-)
+require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=
-github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/main_test.go
+++ b/main_test.go
@@ -1,552 +1,66 @@
 package main
 
 import (
-	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCleanSDCard(t *testing.T) {
-	t.Skip("This test requires actual RAW/JPG files with EXIF data. Use TestDetectConsecutiveDays for unit testing the folder logic.")
+	dirTest := "test"
+	dirSrc := filepath.Join(dirTest, "src")
+	dirDst := filepath.Join(dirTest, "dst")
+	editFileExtensions := []string{"xmp"}
+	extensionsToCopy := []string{"raw"}
+	flagDryRun := false
+	flagOverwrite := false
+	flagDeleteZombieEditFiles := false
 
-	// Note: The new implementation requires EXIF data to be present in files.
-	// Creating empty dummy files won't work anymore since copyFiles now reads EXIF dates.
-	// For proper integration testing, you would need actual RAW/JPG files with EXIF data.
-	// The core logic is tested in TestDetectConsecutiveDays, TestGroupFilesByDate, and TestIsConsecutiveDay.
-	//
-	// Integration test scenarios to verify:
-	// 1. RAW files (.arw, .raw) are always copied to dirDst
-	// 2. When flagKeepJPGs=true: JPG files remain untouched on source
-	// 3. When flagKeepJPGs=false: JPG files copied to dirDstJPGs
-	// 4. Both RAW and JPG use same EXIF-based folder organization
-	// 5. Dry-run mode prevents all file operations
-}
+	fileCount := 30
 
-func TestFlagDefaults(t *testing.T) {
-	// Create a new flag set to test defaults without affecting global state
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	defer func() {
+		if err := os.RemoveAll(dirTest); err != nil {
+			t.Errorf("failed to remove %s after test, delete the dir manually: %v", dirSrc, err)
+		}
+	}()
 
-	var flagKeepJPGs bool
-	fs.BoolVar(&flagKeepJPGs, "keep-jpgs", true, "Keep JPG files")
-
-	// Parse with no args to get defaults
-	err := fs.Parse([]string{})
+	// create dummy files in src directory
+	err := os.MkdirAll(dirSrc, 0755)
 	require.NoError(t, err)
-
-	assert.True(t, flagKeepJPGs, "flagKeepJPGs should default to true")
-}
-
-func TestGroupFilesByDate(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []fileWithDate
-		expected []dateGroup
-	}{
-		{
-			name: "single day with multiple files",
-			input: []fileWithDate{
-				{name: "file1.arw", date: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)},
-				{name: "file2.arw", date: time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)},
-				{name: "file3.arw", date: time.Date(2026, 1, 15, 18, 45, 0, 0, time.UTC)},
-			},
-			expected: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
-					files: []string{"file1.arw", "file2.arw", "file3.arw"},
-				},
-			},
-		},
-		{
-			name: "multiple days",
-			input: []fileWithDate{
-				{name: "file1.arw", date: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)},
-				{name: "file2.arw", date: time.Date(2026, 1, 16, 10, 0, 0, 0, time.UTC)},
-				{name: "file3.arw", date: time.Date(2026, 1, 15, 14, 0, 0, 0, time.UTC)},
-			},
-			expected: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
-					files: []string{"file1.arw", "file3.arw"},
-				},
-				{
-					date:  time.Date(2026, 1, 16, 10, 0, 0, 0, time.UTC),
-					files: []string{"file2.arw"},
-				},
-			},
-		},
-		{
-			name:     "empty input",
-			input:    []fileWithDate{},
-			expected: []dateGroup{},
-		},
+	for i := range fileCount {
+		filePath := filepath.Join(dirSrc, fmt.Sprintf("file%d.%s", i+1, extensionsToCopy[0]))
+		if _, err := os.Create(filePath); err != nil {
+			require.NoError(t, err)
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := groupFilesByDate(tt.input)
+	totalCopied, removedCount, err := cleanSDCard(editFileExtensions, extensionsToCopy, dirSrc, dirDst, flagDryRun, flagOverwrite, flagDeleteZombieEditFiles)
 
-			require.Len(t, result, len(tt.expected))
+	assert.NoError(t, err)
+	assert.Equal(t, fileCount, totalCopied)
+	assert.Equal(t, fileCount, removedCount)
 
-			// Sort both for comparison
-			for i := range result {
-				for j := i + 1; j < len(result); j++ {
-					if result[i].date.After(result[j].date) {
-						result[i], result[j] = result[j], result[i]
-					}
-				}
-			}
+	entries, err := os.ReadDir(dirDst)
+	assert.NoError(t, err)
+	assert.Equal(t, fileCount, len(entries))
 
-			for i, expected := range tt.expected {
-				assert.Equal(t, expected.date.Format("2006-01-02"), result[i].date.Format("2006-01-02"))
-				assert.ElementsMatch(t, expected.files, result[i].files)
-			}
-		})
-	}
-}
-
-func TestIsConsecutiveDay(t *testing.T) {
-	tests := []struct {
-		name     string
-		date1    time.Time
-		date2    time.Time
-		expected bool
-	}{
-		{
-			name:     "consecutive days",
-			date1:    time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
-			date2:    time.Date(2026, 1, 16, 14, 0, 0, 0, time.UTC),
-			expected: true,
-		},
-		{
-			name:     "non-consecutive days",
-			date1:    time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
-			date2:    time.Date(2026, 1, 17, 10, 0, 0, 0, time.UTC),
-			expected: false,
-		},
-		{
-			name:     "same day",
-			date1:    time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
-			date2:    time.Date(2026, 1, 15, 18, 0, 0, 0, time.UTC),
-			expected: false,
-		},
-		{
-			name:     "consecutive days across month boundary",
-			date1:    time.Date(2026, 1, 31, 10, 0, 0, 0, time.UTC),
-			date2:    time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC),
-			expected: true,
-		},
-		{
-			name:     "consecutive days across year boundary",
-			date1:    time.Date(2025, 12, 31, 10, 0, 0, 0, time.UTC),
-			date2:    time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC),
-			expected: true,
-		},
+	copiedFiles := make([]string, len(entries))
+	for i, entry := range entries {
+		copiedFiles[i] = entry.Name()
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isConsecutiveDay(tt.date1, tt.date2)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestDetectConsecutiveDays(t *testing.T) {
-	tests := []struct {
-		name                               string
-		dateGroups                         []dateGroup
-		thresholdOneDay                    int
-		thresholdConsecutiveDays           int
-		expectedGroupCount                 int
-		expectedDestDirs                   []string
-		expectedFilesPerGroup              []int
-		description                        string
-	}{
-		{
-			name: "two consecutive days with 400 photos each - should be grouped",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(400, "day1"),
-				},
-				{
-					date:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(400, "day2"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260101-20260102"},
-			expectedFilesPerGroup:    []int{800},
-			description:              "Jan 1: 400 photos, Jan 2: 400 photos → grouped (20260101-20260102)",
-		},
-		{
-			name: "three consecutive days with 350 photos each - should be grouped",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(350, "day1"),
-				},
-				{
-					date:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(350, "day2"),
-				},
-				{
-					date:  time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(350, "day3"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260101-20260103"},
-			expectedFilesPerGroup:    []int{1050},
-			description:              "3 consecutive days with 350 photos each → grouped",
-		},
-		{
-			name: "single day with 700 photos - should get own folder",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(700, "day15"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260115"},
-			expectedFilesPerGroup:    []int{700},
-			description:              "Single day with 700 photos → own folder (20260115)",
-		},
-		{
-			name: "low volume day - should go to root",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(200, "day15"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"."},
-			expectedFilesPerGroup:    []int{200},
-			description:              "Single day with 200 photos → root directory",
-		},
-		{
-			name: "mixed scenario - consecutive event + isolated high volume day + low volume days",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(400, "day1"),
-				},
-				{
-					date:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(350, "day2"),
-				},
-				{
-					date:  time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(700, "day5"),
-				},
-				{
-					date:  time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(150, "day10"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       3,
-			expectedDestDirs:         []string{"20260101-20260102", "20260105", "."},
-			expectedFilesPerGroup:    []int{750, 700, 150},
-			description:              "Mixed: consecutive event (Jan 1-2), high volume day (Jan 5), low volume day (Jan 10)",
-		},
-		{
-			name: "consecutive days but only first exceeds threshold - should not group",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(400, "day1"),
-				},
-				{
-					date:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(250, "day2"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       2,
-			expectedDestDirs:         []string{".", "."},
-			expectedFilesPerGroup:    []int{400, 250},
-			description:              "Day 1: 400 photos, Day 2: 250 photos → both to root (second day < 300)",
-		},
-		{
-			name: "gap in consecutive days - should create separate groups",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(400, "day1"),
-				},
-				{
-					date:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(400, "day2"),
-				},
-				{
-					date:  time.Date(2026, 1, 4, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(400, "day4"),
-				},
-				{
-					date:  time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(400, "day5"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       2,
-			expectedDestDirs:         []string{"20260101-20260102", "20260104-20260105"},
-			expectedFilesPerGroup:    []int{800, 800},
-			description:              "Two separate consecutive events with gap on Jan 3",
-		},
-		{
-			name: "single day with 1000 photos - well above threshold",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 2, 14, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(1000, "valentine"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260214"},
-			expectedFilesPerGroup:    []int{1000},
-			description:              "Single day with 1000 photos (well above 600 threshold) → own folder",
-		},
-		{
-			name: "consecutive days with 800 photos each - high volume event",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(800, "day1"),
-				},
-				{
-					date:  time.Date(2026, 3, 11, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(850, "day2"),
-				},
-				{
-					date:  time.Date(2026, 3, 12, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(900, "day3"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260310-20260312"},
-			expectedFilesPerGroup:    []int{2550},
-			description:              "3 consecutive days with 800+ photos each → grouped (exceeds both thresholds)",
-		},
-		{
-			name: "consecutive days at exactly threshold values",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(600, "day1"),
-				},
-				{
-					date:  time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(300, "day2"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260401-20260402"},
-			expectedFilesPerGroup:    []int{900},
-			description:              "Day 1: exactly 600, Day 2: exactly 300 → grouped (both ≥300)",
-		},
-		{
-			name: "week-long event with varying high volumes",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(500, "day1"),
-				},
-				{
-					date:  time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(600, "day2"),
-				},
-				{
-					date:  time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(700, "day3"),
-				},
-				{
-					date:  time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(650, "day4"),
-				},
-				{
-					date:  time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(550, "day5"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260501-20260505"},
-			expectedFilesPerGroup:    []int{3000},
-			description:              "5 consecutive days with 500-700 photos (all ≥300) → grouped as single event",
-		},
-		{
-			name: "single day exactly at threshold - edge case",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(600, "day15"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260615"},
-			expectedFilesPerGroup:    []int{600},
-			description:              "Single day with exactly 600 photos → own folder (at threshold boundary)",
-		},
-		{
-			name: "single day just below threshold",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(599, "day16"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"."},
-			expectedFilesPerGroup:    []int{599},
-			description:              "Single day with 599 photos (one below threshold) → root directory",
-		},
-		{
-			name: "massive multi-day event - 2000+ photos per day",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(2000, "day1"),
-				},
-				{
-					date:  time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(2500, "day2"),
-				},
-				{
-					date:  time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(1800, "day3"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260701-20260703"},
-			expectedFilesPerGroup:    []int{6300},
-			description:              "3 consecutive days with 2000+ photos each → grouped (extreme high volume)",
-		},
-		{
-			name: "alternating high and low volume days",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(800, "day1"),
-				},
-				{
-					date:  time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(200, "day2"),
-				},
-				{
-					date:  time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(900, "day3"),
-				},
-				{
-					date:  time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(150, "day4"),
-				},
-			},
-			thresholdOneDay:          600,
-			thresholdConsecutiveDays: 300,
-			expectedGroupCount:       4,
-			expectedDestDirs:         []string{"20260801", ".", "20260803", "."},
-			expectedFilesPerGroup:    []int{800, 200, 900, 150},
-			description:              "Alternating high/low volume → separate folders for high days, root for low days",
-		},
-		{
-			name: "different thresholds - lower values for hobby photographer",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(150, "day1"),
-				},
-				{
-					date:  time.Date(2026, 9, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(120, "day2"),
-				},
-				{
-					date:  time.Date(2026, 9, 3, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(130, "day3"),
-				},
-			},
-			thresholdOneDay:          200, // Lower threshold for hobby use
-			thresholdConsecutiveDays: 100, // Lower threshold for consecutive days
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20260901-20260903"},
-			expectedFilesPerGroup:    []int{400},
-			description:              "Lower thresholds (200/100) → 3 consecutive days with 120-150 photos → grouped",
-		},
-		{
-			name: "different thresholds - higher values for professional photographer",
-			dateGroups: []dateGroup{
-				{
-					date:  time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(800, "day1"),
-				},
-				{
-					date:  time.Date(2026, 10, 2, 0, 0, 0, 0, time.UTC),
-					files: makeFileList(750, "day2"),
-				},
-			},
-			thresholdOneDay:          1000, // Higher threshold for pro use
-			thresholdConsecutiveDays: 500,  // Higher threshold for consecutive days
-			expectedGroupCount:       1,
-			expectedDestDirs:         []string{"20261001-20261002"},
-			expectedFilesPerGroup:    []int{1550},
-			description:              "Higher thresholds (1000/500) → 2 consecutive days with 750-800 photos (both ≥500) → grouped",
-		},
+	expectedFiles := make([]string, fileCount)
+	for i := range fileCount {
+		expectedFiles[i] = fmt.Sprintf("file%d.%s", i+1, extensionsToCopy[0])
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := detectConsecutiveDays(tt.dateGroups, tt.thresholdOneDay, tt.thresholdConsecutiveDays)
+	assert.ElementsMatch(t, copiedFiles, expectedFiles)
 
-			assert.Equal(t, tt.expectedGroupCount, len(result), "Expected %d groups, got %d. %s", tt.expectedGroupCount, len(result), tt.description)
-
-			destDirs := make([]string, len(result))
-			filesPerGroup := make([]int, len(result))
-			for i, group := range result {
-				destDirs[i] = group.destDir
-				filesPerGroup[i] = len(group.files)
-			}
-
-			assert.Equal(t, tt.expectedDestDirs, destDirs, "Destination directories don't match. %s", tt.description)
-			assert.Equal(t, tt.expectedFilesPerGroup, filesPerGroup, "Files per group don't match. %s", tt.description)
-		})
-	}
-}
-
-// Helper function to create a list of file names
-func makeFileList(count int, prefix string) []string {
-	files := make([]string, count)
-	for i := 0; i < count; i++ {
-		files[i] = fmt.Sprintf("%s_file%d.arw", prefix, i+1)
-	}
-	return files
+	entries, err := os.ReadDir(dirSrc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(entries))
 }


### PR DESCRIPTION
This pull request reverts commit 347c504d1d55874a9b70139aa9b3701a3fb28272, which was the merge commit for pull request #1.

Reason for Revert
This revert was requested to undo the changes from commit 347c504d1d55874a9b70139aa9b3701a3fb28272.

Original Pull Request
* PR: #1
* Title: feat: EXIF-based folder organization with comprehensive tests
* Author: @SDTakeuchi

Changes in this Revert
This PR undoes the changes introduced in #1, which includes:
* Reverting the EXIF-based folder organization feature.
* Restoring the previous file copying logic.
* Reverting changes to the configuration and tests related to the feature.
