### PR TITLE
Refactor: extract shared concurrent fan-out helper

### DIFF
--- a/main.go
+++ b/main.go
@@ -169,6 +169,35 @@ func (e fileCopyError) Error() string {
 	return fmt.Sprintf("failed to copy file %s: %s", e.fileName, e.err.Error())
 }
 
+// forEachEntryConcurrently runs fn concurrently for each entry, aggregating
+// the increments fn reports and any errors it returns.
+func forEachEntryConcurrently(entries []os.DirEntry, fn func(entry os.DirEntry) (int, error)) (int, error) {
+	var count atomic.Int32
+	var wg sync.WaitGroup
+	errsChan := make(chan error, len(entries))
+
+	for _, entry := range entries {
+		wg.Go(func() {
+			n, err := fn(entry)
+			if err != nil {
+				errsChan <- err
+				return
+			}
+			count.Add(int32(n))
+		})
+	}
+
+	wg.Wait()
+	close(errsChan)
+
+	var errs error
+	for e := range errsChan {
+		errs = errors.Join(errs, e)
+	}
+
+	return int(count.Load()), errs
+}
+
 // copyFiles copies files with the given extension from srcDir to dstDir.
 // If flagDryRun is true, it counts files without copying.
 // If flagOverwrite is true, it overwrites existing files in dstDir.
@@ -179,55 +208,38 @@ func copyFiles(srcDir, dstDir, ext string, flagDryRun, flagOverwrite bool) (int,
 		return 0, err
 	}
 
-	var count atomic.Int32
-	var wg sync.WaitGroup
-	errsChan := make(chan fileCopyError, len(entries))
-
-	for _, entry := range entries {
+	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
 		if entry.IsDir() {
-			continue
+			return 0, nil
 		}
 
-		wg.Go(func() {
-			name := entry.Name()
-			if !strings.EqualFold(filepath.Ext(name), "."+ext) {
-				return
+		name := entry.Name()
+		if !strings.EqualFold(filepath.Ext(name), "."+ext) {
+			return 0, nil
+		}
+
+		srcPath := filepath.Join(srcDir, name)
+		dstPath := filepath.Join(dstDir, name)
+
+		if !flagOverwrite {
+			if _, statErr := os.Stat(dstPath); statErr == nil {
+				log.Printf("skipping copying existing file: %s\n", name)
+				return 0, nil
 			}
+		}
 
-			srcPath := filepath.Join(srcDir, name)
-			dstPath := filepath.Join(dstDir, name)
+		if flagDryRun {
+			log.Printf("[dry-run] would copy %s\n", name)
+			return 1, nil
+		}
 
-			if !flagOverwrite {
-				if _, statErr := os.Stat(dstPath); statErr == nil {
-					log.Printf("skipping copying existing file: %s\n", name)
-					return
-				}
-			}
+		if copyErr := copyFile(srcPath, dstPath); copyErr != nil {
+			return 0, fileCopyError{fileName: name, err: copyErr}
+		}
 
-			if flagDryRun {
-				log.Printf("[dry-run] would copy %s\n", name)
-				count.Add(1)
-				return
-			}
-
-			if copyErr := copyFile(srcPath, dstPath); copyErr != nil {
-				errsChan <- fileCopyError{fileName: name, err: copyErr}
-				return
-			}
-
-			log.Printf("copied %s\n", name)
-			count.Add(1)
-		})
-	}
-
-	wg.Wait()
-	close(errsChan)
-
-	for e := range errsChan {
-		err = errors.Join(err, e)
-	}
-
-	return int(count.Load()), err
+		log.Printf("copied %s\n", name)
+		return 1, nil
+	})
 }
 
 // copyFile copies a single file from src to dst.
@@ -256,34 +268,18 @@ func removeFiles(dir string) (int, error) {
 		return 0, err
 	}
 
-	var count atomic.Int32
-	var wg sync.WaitGroup
-	errsChan := make(chan error, len(entries))
-
-	for _, entry := range entries {
+	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
 		if entry.IsDir() {
-			continue
+			return 0, nil
 		}
 
-		wg.Go(func() {
-			path := filepath.Join(dir, entry.Name())
-			if err := os.Remove(path); err != nil {
-				errsChan <- fmt.Errorf("failed to remove file %s: %w", entry.Name(), err)
-				return
-			}
-			log.Printf("removed %s\n", entry.Name())
-			count.Add(1)
-		})
-	}
-
-	wg.Wait()
-	close(errsChan)
-
-	for e := range errsChan {
-		err = errors.Join(err, e)
-	}
-
-	return int(count.Load()), err
+		path := filepath.Join(dir, entry.Name())
+		if err := os.Remove(path); err != nil {
+			return 0, fmt.Errorf("failed to remove file %s: %w", entry.Name(), err)
+		}
+		log.Printf("removed %s\n", entry.Name())
+		return 1, nil
+	})
 }
 
 // deleteZombieEditFiles deletes edit files that have no corresponding raw file.
@@ -296,64 +292,41 @@ func deleteZombieEditFiles(editFileExtension, dir string, rawFileExtensions []st
 		return 0, fmt.Errorf("reading directory: %w", err)
 	}
 
-	var count atomic.Int32
-	var wg sync.WaitGroup
-	errsChan := make(chan error, len(entries))
-
-	for _, entry := range entries {
-		wg.Go(func() {
-			if entry.IsDir() {
-				if isRecursive {
-					n, err := deleteZombieEditFiles(editFileExtension, filepath.Join(dir, entry.Name()), rawFileExtensions, isRecursive)
-					if err != nil {
-						errsChan <- fmt.Errorf("failed to process subdirectory %s: %w", entry.Name(), err)
-						return
-					}
-					count.Add(int32(n))
-				}
-				return
+	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
+		if entry.IsDir() {
+			if !isRecursive {
+				return 0, nil
 			}
-
-			editFileName := entry.Name()
-			if !strings.HasSuffix(editFileName, "."+editFileExtension) {
-				return
+			n, err := deleteZombieEditFiles(editFileExtension, filepath.Join(dir, entry.Name()), rawFileExtensions, isRecursive)
+			if err != nil {
+				return 0, fmt.Errorf("failed to process subdirectory %s: %w", entry.Name(), err)
 			}
+			return n, nil
+		}
 
-			editFileNameWithoutExt := strings.TrimSuffix(editFileName, "."+editFileExtension)
+		editFileName := entry.Name()
+		if !strings.HasSuffix(editFileName, "."+editFileExtension) {
+			return 0, nil
+		}
 
-			hasCorrespondingRawFile := false
-			for _, rawFileExt := range rawFileExtensions {
-				expectedRawFileName := editFileNameWithoutExt + "." + rawFileExt
-				if _, err := os.Stat(filepath.Join(dir, expectedRawFileName)); err == nil {
-					hasCorrespondingRawFile = true
-					break
-				} else if !errors.Is(err, os.ErrNotExist) {
-					errsChan <- fmt.Errorf("failed to check if %s exists: %w", expectedRawFileName, err)
-					return
-				}
+		editFileNameWithoutExt := strings.TrimSuffix(editFileName, "."+editFileExtension)
+
+		for _, rawFileExt := range rawFileExtensions {
+			expectedRawFileName := editFileNameWithoutExt + "." + rawFileExt
+			if _, err := os.Stat(filepath.Join(dir, expectedRawFileName)); err == nil {
+				return 0, nil
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return 0, fmt.Errorf("failed to check if %s exists: %w", expectedRawFileName, err)
 			}
-			if hasCorrespondingRawFile {
-				return
-			}
+		}
 
-			if err := os.Remove(filepath.Join(dir, editFileName)); err != nil {
-				errsChan <- fmt.Errorf("failed to remove zombie edit file %s: %w", editFileName, err)
-				return
-			}
+		if err := os.Remove(filepath.Join(dir, editFileName)); err != nil {
+			return 0, fmt.Errorf("failed to remove zombie edit file %s: %w", editFileName, err)
+		}
 
-			log.Printf("removed zombie edit file: %s\n", editFileName)
-			count.Add(1)
-		})
-	}
-
-	wg.Wait()
-	close(errsChan)
-
-	for e := range errsChan {
-		err = errors.Join(err, e)
-	}
-
-	return int(count.Load()), err
+		log.Printf("removed zombie edit file: %s\n", editFileName)
+		return 1, nil
+	})
 }
 
 func countFilesWithExtension(dir, ext string) (int, error) {


### PR DESCRIPTION
## Summary
- `copyFiles`, `removeFiles`, and `deleteZombieEditFiles` each repeated the same WaitGroup + atomic counter + buffered error channel boilerplate
- Extract `forEachEntryConcurrently(entries, fn)` so each caller only supplies the per-entry logic and an increment/error result
- Stacked on #5 (Options struct); diff here is scoped to the fan-out extraction only

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] TestCopyFilesDeadlock passes (confirms the earlier deadlock fix survived the extraction)
- [x] Verified TestDeleteZombieEditFiles subtests fail identically on unmodified main (pre-existing Windows file-locking flakiness, not a regression)