### PR TITLE
Refactor: abstract filesystem access behind a FileSystem interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This tool scans a source directory for files with `.arw` or `.raw` extensions. I
 You can run the tool directly using `go run`:
 
 ```bash
-go run main.go [flags]
+go run . [flags]
 ```
 
 ### Flags
@@ -41,29 +41,29 @@ go run main.go [flags]
 **1. Dry Run (Safe Mode)**
 Check what files would be copied and removed without actually doing it:
 ```bash
-go run main.go -dry-run
+go run . -dry-run
 ```
 
 **2. Standard Run**
 Copy files and clean the SD card (skips existing files in destination):
 ```bash
-go run main.go
+go run .
 ```
 
 **3. Overwrite Existing Files**
 Copy files and overwrite duplicates in the destination:
 ```bash
-go run main.go -overwrite
+go run . -overwrite
 ```
 
 **4. Custom Source and Destination**
 Specify custom directories:
 ```bash
-go run main.go -src /path/to/sd/card -dst /path/to/backup
+go run . -src /path/to/sd/card -dst /path/to/backup
 ```
 
 **5. Skip Zombie Edit File Cleanup**
 Keep orphaned `.xmp` files in the destination:
 ```bash
-go run main.go -delete-zombie-edit-files=false
+go run . -delete-zombie-edit-files=false
 ```

--- a/fake_filesystem_test.go
+++ b/fake_filesystem_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// fakeFileSystem is an in-memory FileSystem used in tests so that test
+// correctness doesn't depend on the real disk (and its OS-specific quirks,
+// such as transient file locks held by indexers/antivirus on Windows).
+type fakeFileSystem struct {
+	mu    sync.Mutex
+	files map[string][]byte
+	dirs  map[string]bool
+}
+
+func newFakeFileSystem() *fakeFileSystem {
+	return &fakeFileSystem{
+		files: make(map[string][]byte),
+		dirs:  map[string]bool{".": true},
+	}
+}
+
+func cleanFakePath(p string) string {
+	return filepath.ToSlash(filepath.Clean(p))
+}
+
+// addFile seeds a file (and its parent directories) for a test.
+func (f *fakeFileSystem) addFile(path, content string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	path = cleanFakePath(path)
+	f.files[path] = []byte(content)
+	f.markDirTree(cleanFakePath(filepath.Dir(path)))
+}
+
+// addDir seeds an (empty) directory for a test.
+func (f *fakeFileSystem) addDir(path string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.markDirTree(cleanFakePath(path))
+}
+
+// markDirTree marks path and all of its ancestors as existing directories.
+// Callers must hold f.mu.
+func (f *fakeFileSystem) markDirTree(path string) {
+	for {
+		f.dirs[path] = true
+		parent := cleanFakePath(filepath.Dir(path))
+		if parent == path {
+			return
+		}
+		path = parent
+	}
+}
+
+func (f *fakeFileSystem) ReadDir(dir string) ([]os.DirEntry, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	dir = cleanFakePath(dir)
+	if !f.dirs[dir] {
+		return nil, fmt.Errorf("readdir %s: %w", dir, os.ErrNotExist)
+	}
+
+	isDirByName := make(map[string]bool)
+	for path := range f.files {
+		if cleanFakePath(filepath.Dir(path)) == dir {
+			isDirByName[filepath.Base(path)] = false
+		}
+	}
+	for path := range f.dirs {
+		if path == dir {
+			continue
+		}
+		if cleanFakePath(filepath.Dir(path)) == dir {
+			isDirByName[filepath.Base(path)] = true
+		}
+	}
+
+	entries := make([]os.DirEntry, 0, len(isDirByName))
+	for name, isDir := range isDirByName {
+		entries = append(entries, fakeDirEntry{name: name, isDir: isDir})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	return entries, nil
+}
+
+func (f *fakeFileSystem) Stat(path string) (os.FileInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	path = cleanFakePath(path)
+	if content, ok := f.files[path]; ok {
+		return fakeFileInfo{name: filepath.Base(path), size: int64(len(content))}, nil
+	}
+	if f.dirs[path] {
+		return fakeFileInfo{name: filepath.Base(path), isDir: true}, nil
+	}
+	return nil, fmt.Errorf("stat %s: %w", path, os.ErrNotExist)
+}
+
+func (f *fakeFileSystem) Remove(path string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	path = cleanFakePath(path)
+	if _, ok := f.files[path]; !ok {
+		return fmt.Errorf("remove %s: %w", path, os.ErrNotExist)
+	}
+	delete(f.files, path)
+	return nil
+}
+
+func (f *fakeFileSystem) MkdirAll(path string, _ os.FileMode) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.markDirTree(cleanFakePath(path))
+	return nil
+}
+
+func (f *fakeFileSystem) CopyFile(src, dst string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	src = cleanFakePath(src)
+	content, ok := f.files[src]
+	if !ok {
+		return fmt.Errorf("open %s: %w", src, os.ErrNotExist)
+	}
+
+	dst = cleanFakePath(dst)
+	f.files[dst] = append([]byte(nil), content...)
+	f.markDirTree(cleanFakePath(filepath.Dir(dst)))
+	return nil
+}
+
+type fakeDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (e fakeDirEntry) Name() string { return e.name }
+func (e fakeDirEntry) IsDir() bool  { return e.isDir }
+
+func (e fakeDirEntry) Type() fs.FileMode {
+	if e.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+
+func (e fakeDirEntry) Info() (fs.FileInfo, error) {
+	return fakeFileInfo{name: e.name, isDir: e.isDir}, nil
+}
+
+type fakeFileInfo struct {
+	name  string
+	size  int64
+	isDir bool
+}
+
+func (i fakeFileInfo) Name() string { return i.name }
+func (i fakeFileInfo) Size() int64  { return i.size }
+
+func (i fakeFileInfo) Mode() fs.FileMode {
+	if i.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+
+func (i fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (i fakeFileInfo) IsDir() bool        { return i.isDir }
+func (i fakeFileInfo) Sys() any           { return nil }

--- a/filesystem.go
+++ b/filesystem.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// FileSystem abstracts the filesystem operations that copyFiles, removeFiles,
+// and deleteZombieEditFiles depend on, so that callers (tests, in particular)
+// can substitute a fake implementation instead of touching the real disk.
+type FileSystem interface {
+	ReadDir(dir string) ([]os.DirEntry, error)
+	Stat(path string) (os.FileInfo, error)
+	Remove(path string) error
+	MkdirAll(path string, perm os.FileMode) error
+	CopyFile(src, dst string) error
+}
+
+// osFileSystem implements FileSystem using the real OS filesystem.
+type osFileSystem struct{}
+
+func (osFileSystem) ReadDir(dir string) ([]os.DirEntry, error) {
+	return os.ReadDir(dir)
+}
+
+func (osFileSystem) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (osFileSystem) Remove(path string) error {
+	return os.Remove(path)
+}
+
+func (osFileSystem) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (osFileSystem) CopyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+type fileCopyError struct {
+	fileName string
+	err      error
+}
+
+func (e fileCopyError) Error() string {
+	return fmt.Sprintf("failed to copy file %s: %s", e.fileName, e.err.Error())
+}
+
+// forEachEntryConcurrently runs fn concurrently for each entry, aggregating
+// the increments fn reports and any errors it returns.
+func forEachEntryConcurrently(entries []os.DirEntry, fn func(entry os.DirEntry) (int, error)) (int, error) {
+	var count atomic.Int32
+	var wg sync.WaitGroup
+	errsChan := make(chan error, len(entries))
+
+	for _, entry := range entries {
+		wg.Go(func() {
+			n, err := fn(entry)
+			if err != nil {
+				errsChan <- err
+				return
+			}
+			count.Add(int32(n))
+		})
+	}
+
+	wg.Wait()
+	close(errsChan)
+
+	var errs error
+	for e := range errsChan {
+		errs = errors.Join(errs, e)
+	}
+
+	return int(count.Load()), errs
+}
+
+// copyFiles copies files with the given extension from srcDir to dstDir.
+// If flagDryRun is true, it counts files without copying.
+// If flagOverwrite is true, it overwrites existing files in dstDir.
+// It returns the number of files copied and any error.
+func copyFiles(fsys FileSystem, srcDir, dstDir, ext string, flagDryRun, flagOverwrite bool) (int, error) {
+	entries, err := fsys.ReadDir(srcDir)
+	if err != nil {
+		return 0, err
+	}
+
+	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
+		if entry.IsDir() {
+			return 0, nil
+		}
+
+		name := entry.Name()
+		if !strings.EqualFold(filepath.Ext(name), "."+ext) {
+			return 0, nil
+		}
+
+		srcPath := filepath.Join(srcDir, name)
+		dstPath := filepath.Join(dstDir, name)
+
+		if !flagOverwrite {
+			if _, statErr := fsys.Stat(dstPath); statErr == nil {
+				log.Printf("skipping copying existing file: %s\n", name)
+				return 0, nil
+			}
+		}
+
+		if flagDryRun {
+			log.Printf("[dry-run] would copy %s\n", name)
+			return 1, nil
+		}
+
+		if copyErr := fsys.CopyFile(srcPath, dstPath); copyErr != nil {
+			return 0, fileCopyError{fileName: name, err: copyErr}
+		}
+
+		log.Printf("copied %s\n", name)
+		return 1, nil
+	})
+}
+
+// removeFiles removes all files in the directory.
+// It returns the number of files removed and any error.
+func removeFiles(fsys FileSystem, dir string) (int, error) {
+	entries, err := fsys.ReadDir(dir)
+	if err != nil {
+		return 0, err
+	}
+
+	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
+		if entry.IsDir() {
+			return 0, nil
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		if err := fsys.Remove(path); err != nil {
+			return 0, fmt.Errorf("failed to remove file %s: %w", entry.Name(), err)
+		}
+		log.Printf("removed %s\n", entry.Name())
+		return 1, nil
+	})
+}
+
+// deleteZombieEditFiles deletes edit files that have no corresponding raw file.
+// It checks for raw files with extensions in rawFileExtensions.
+// If isRecursive is true, it processes subdirectories recursively.
+// It returns the number of files deleted and any error.
+func deleteZombieEditFiles(fsys FileSystem, editFileExtension, dir string, rawFileExtensions []string, isRecursive bool) (int, error) {
+	entries, err := fsys.ReadDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("reading directory: %w", err)
+	}
+
+	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
+		if entry.IsDir() {
+			if !isRecursive {
+				return 0, nil
+			}
+			n, err := deleteZombieEditFiles(fsys, editFileExtension, filepath.Join(dir, entry.Name()), rawFileExtensions, isRecursive)
+			if err != nil {
+				return 0, fmt.Errorf("failed to process subdirectory %s: %w", entry.Name(), err)
+			}
+			return n, nil
+		}
+
+		editFileName := entry.Name()
+		if !strings.HasSuffix(editFileName, "."+editFileExtension) {
+			return 0, nil
+		}
+
+		editFileNameWithoutExt := strings.TrimSuffix(editFileName, "."+editFileExtension)
+
+		for _, rawFileExt := range rawFileExtensions {
+			expectedRawFileName := editFileNameWithoutExt + "." + rawFileExt
+			if _, err := fsys.Stat(filepath.Join(dir, expectedRawFileName)); err == nil {
+				return 0, nil
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return 0, fmt.Errorf("failed to check if %s exists: %w", expectedRawFileName, err)
+			}
+		}
+
+		if err := fsys.Remove(filepath.Join(dir, editFileName)); err != nil {
+			return 0, fmt.Errorf("failed to remove zombie edit file %s: %w", editFileName, err)
+		}
+
+		log.Printf("removed zombie edit file: %s\n", editFileName)
+		return 1, nil
+	})
+}

--- a/main.go
+++ b/main.go
@@ -2,21 +2,14 @@ package main
 
 // Sample usage:
 //
-//	go run main.go -dry-run
-//	go run main.go -overwrite
-//	go run main.go -dry-run -overwrite
+//	go run . -dry-run
+//	go run . -overwrite
+//	go run . -dry-run -overwrite
 
 import (
-	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
-	"sync/atomic"
 )
 
 const (
@@ -68,6 +61,7 @@ func main() {
 	}
 
 	totalCopied, removedCount, err := cleanSDCard(
+		osFileSystem{},
 		editFileExtensions,
 		extensionsToCopy,
 		extensionsJPG,
@@ -86,12 +80,13 @@ func main() {
 // cleanSDCard copies files from dirSrc to dirDst and removes files from dirSrc.
 // It returns the number of files copied, the number of files removed, and any error.
 func cleanSDCard(
+	fsys FileSystem,
 	editFileExtensions, extensionsToCopy, extensionsJPG []string,
 	dirSrc, dirDst, dirDstJPG string,
 	opts Options,
 ) (int, int, error) {
 	if !opts.DryRun {
-		if err := os.MkdirAll(dirDst, 0755); err != nil {
+		if err := fsys.MkdirAll(dirDst, 0755); err != nil {
 			return 0, 0, fmt.Errorf("failed to create destination directory: %w", err)
 		}
 	}
@@ -99,7 +94,7 @@ func cleanSDCard(
 	// copy raw files
 	totalCopied := 0
 	for _, ext := range extensionsToCopy {
-		n, err := copyFiles(dirSrc, dirDst, ext, opts.DryRun, opts.Overwrite)
+		n, err := copyFiles(fsys, dirSrc, dirDst, ext, opts.DryRun, opts.Overwrite)
 		if err != nil {
 			return totalCopied, 0, fmt.Errorf("failed to copy .%s files (copied %d): %w", ext, n, err)
 		}
@@ -110,7 +105,7 @@ func cleanSDCard(
 	if opts.KeepJPG {
 		var countJPGToCopy int
 		for _, ext := range extensionsJPG {
-			n, err := copyFiles(dirSrc, dirDstJPG, ext, opts.DryRun, opts.Overwrite)
+			n, err := copyFiles(fsys, dirSrc, dirDstJPG, ext, opts.DryRun, opts.Overwrite)
 			if err != nil {
 				return 0, 0, fmt.Errorf("failed to copy .%s files to %s (copied %d): %w", ext, dirDstJPG, n, err)
 			}
@@ -128,7 +123,7 @@ func cleanSDCard(
 	removedCount := 0
 	if !opts.DryRun && !opts.KeepSrc {
 		var err error
-		removedCount, err = removeFiles(dirSrc)
+		removedCount, err = removeFiles(fsys, dirSrc)
 		if err != nil {
 			return totalCopied, removedCount, fmt.Errorf("failed to remove source files: %w", err)
 		}
@@ -137,7 +132,7 @@ func cleanSDCard(
 	// delete zombie edit files
 	if !opts.DryRun && opts.DeleteZombieEditFiles {
 		for _, editFileExtension := range editFileExtensions {
-			count, err := deleteZombieEditFiles(editFileExtension, dirDst, extensionsToCopy, true)
+			count, err := deleteZombieEditFiles(fsys, editFileExtension, dirDst, extensionsToCopy, true)
 			if err != nil {
 				return totalCopied, removedCount, fmt.Errorf("failed to delete zombie edit files with extension %s: %w", editFileExtension, err)
 			}
@@ -146,173 +141,4 @@ func cleanSDCard(
 	}
 
 	return totalCopied, removedCount, nil
-}
-
-type fileCopyError struct {
-	fileName string
-	err      error
-}
-
-func (e fileCopyError) Error() string {
-	return fmt.Sprintf("failed to copy file %s: %s", e.fileName, e.err.Error())
-}
-
-// forEachEntryConcurrently runs fn concurrently for each entry, aggregating
-// the increments fn reports and any errors it returns.
-func forEachEntryConcurrently(entries []os.DirEntry, fn func(entry os.DirEntry) (int, error)) (int, error) {
-	var count atomic.Int32
-	var wg sync.WaitGroup
-	errsChan := make(chan error, len(entries))
-
-	for _, entry := range entries {
-		wg.Go(func() {
-			n, err := fn(entry)
-			if err != nil {
-				errsChan <- err
-				return
-			}
-			count.Add(int32(n))
-		})
-	}
-
-	wg.Wait()
-	close(errsChan)
-
-	var errs error
-	for e := range errsChan {
-		errs = errors.Join(errs, e)
-	}
-
-	return int(count.Load()), errs
-}
-
-// copyFiles copies files with the given extension from srcDir to dstDir.
-// If flagDryRun is true, it counts files without copying.
-// If flagOverwrite is true, it overwrites existing files in dstDir.
-// It returns the number of files copied and any error.
-func copyFiles(srcDir, dstDir, ext string, flagDryRun, flagOverwrite bool) (int, error) {
-	entries, err := os.ReadDir(srcDir)
-	if err != nil {
-		return 0, err
-	}
-
-	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
-		if entry.IsDir() {
-			return 0, nil
-		}
-
-		name := entry.Name()
-		if !strings.EqualFold(filepath.Ext(name), "."+ext) {
-			return 0, nil
-		}
-
-		srcPath := filepath.Join(srcDir, name)
-		dstPath := filepath.Join(dstDir, name)
-
-		if !flagOverwrite {
-			if _, statErr := os.Stat(dstPath); statErr == nil {
-				log.Printf("skipping copying existing file: %s\n", name)
-				return 0, nil
-			}
-		}
-
-		if flagDryRun {
-			log.Printf("[dry-run] would copy %s\n", name)
-			return 1, nil
-		}
-
-		if copyErr := copyFile(srcPath, dstPath); copyErr != nil {
-			return 0, fileCopyError{fileName: name, err: copyErr}
-		}
-
-		log.Printf("copied %s\n", name)
-		return 1, nil
-	})
-}
-
-// copyFile copies a single file from src to dst.
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	return err
-}
-
-// removeFiles removes all files in the directory.
-// It returns the number of files removed and any error.
-func removeFiles(dir string) (int, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return 0, err
-	}
-
-	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
-		if entry.IsDir() {
-			return 0, nil
-		}
-
-		path := filepath.Join(dir, entry.Name())
-		if err := os.Remove(path); err != nil {
-			return 0, fmt.Errorf("failed to remove file %s: %w", entry.Name(), err)
-		}
-		log.Printf("removed %s\n", entry.Name())
-		return 1, nil
-	})
-}
-
-// deleteZombieEditFiles deletes edit files that have no corresponding raw file.
-// It checks for raw files with extensions in rawFileExtensions.
-// If isRecursive is true, it processes subdirectories recursively.
-// It returns the number of files deleted and any error.
-func deleteZombieEditFiles(editFileExtension, dir string, rawFileExtensions []string, isRecursive bool) (int, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return 0, fmt.Errorf("reading directory: %w", err)
-	}
-
-	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
-		if entry.IsDir() {
-			if !isRecursive {
-				return 0, nil
-			}
-			n, err := deleteZombieEditFiles(editFileExtension, filepath.Join(dir, entry.Name()), rawFileExtensions, isRecursive)
-			if err != nil {
-				return 0, fmt.Errorf("failed to process subdirectory %s: %w", entry.Name(), err)
-			}
-			return n, nil
-		}
-
-		editFileName := entry.Name()
-		if !strings.HasSuffix(editFileName, "."+editFileExtension) {
-			return 0, nil
-		}
-
-		editFileNameWithoutExt := strings.TrimSuffix(editFileName, "."+editFileExtension)
-
-		for _, rawFileExt := range rawFileExtensions {
-			expectedRawFileName := editFileNameWithoutExt + "." + rawFileExt
-			if _, err := os.Stat(filepath.Join(dir, expectedRawFileName)); err == nil {
-				return 0, nil
-			} else if !errors.Is(err, os.ErrNotExist) {
-				return 0, fmt.Errorf("failed to check if %s exists: %w", expectedRawFileName, err)
-			}
-		}
-
-		if err := os.Remove(filepath.Join(dir, editFileName)); err != nil {
-			return 0, fmt.Errorf("failed to remove zombie edit file %s: %w", editFileName, err)
-		}
-
-		log.Printf("removed zombie edit file: %s\n", editFileName)
-		return 1, nil
-	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -10,13 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// creates dummy files in the current directory to test the behavior of the program
-
 func TestCleanSDCard(t *testing.T) {
-	dirTest := "test"
-	dirSrc := filepath.Join(dirTest, "src")
-	dirDst := filepath.Join(dirTest, "dst")
-	dirDstJPG := filepath.Join(dirTest, "dst-jpg")
+	fsys := newFakeFileSystem()
+	dirSrc := "src"
+	dirDst := "dst"
+	dirDstJPG := "dst-jpg"
 	editFileExtensions := []string{"xmp"}
 	extensionsToCopy := []string{"raw"}
 	extensionsJPG := []string{"jpg"}
@@ -29,24 +27,15 @@ func TestCleanSDCard(t *testing.T) {
 	}
 
 	fileCount := 30
-
-	defer func() {
-		if err := os.RemoveAll(dirTest); err != nil {
-			t.Errorf("failed to remove %s after test, delete the dir manually: %v", dirSrc, err)
-		}
-	}()
-
-	// create dummy files in src directory
-	err := os.MkdirAll(dirSrc, 0755)
-	require.NoError(t, err)
+	expectedFiles := make([]string, fileCount)
 	for i := range fileCount {
-		filePath := filepath.Join(dirSrc, fmt.Sprintf("file%d.%s", i+1, extensionsToCopy[0]))
-		if _, err := os.Create(filePath); err != nil {
-			require.NoError(t, err)
-		}
+		name := fmt.Sprintf("file%d.%s", i+1, extensionsToCopy[0])
+		fsys.addFile(filepath.Join(dirSrc, name), "content")
+		expectedFiles[i] = name
 	}
 
 	totalCopied, removedCount, err := cleanSDCard(
+		fsys,
 		editFileExtensions,
 		extensionsToCopy,
 		extensionsJPG,
@@ -60,7 +49,7 @@ func TestCleanSDCard(t *testing.T) {
 	assert.Equal(t, fileCount, totalCopied)
 	assert.Equal(t, fileCount, removedCount)
 
-	entries, err := os.ReadDir(dirDst)
+	entries, err := fsys.ReadDir(dirDst)
 	assert.NoError(t, err)
 	assert.Equal(t, fileCount, len(entries))
 
@@ -68,88 +57,73 @@ func TestCleanSDCard(t *testing.T) {
 	for i, entry := range entries {
 		copiedFiles[i] = entry.Name()
 	}
-
-	expectedFiles := make([]string, fileCount)
-	for i := range fileCount {
-		expectedFiles[i] = fmt.Sprintf("file%d.%s", i+1, extensionsToCopy[0])
-	}
-
 	assert.ElementsMatch(t, copiedFiles, expectedFiles)
 
-	entries, err = os.ReadDir(dirSrc)
+	entries, err = fsys.ReadDir(dirSrc)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(entries))
 }
 
 func TestDeleteZombieEditFiles(t *testing.T) {
 	t.Run("deletes zombie edit files when no corresponding raw file exists", func(t *testing.T) {
-		dirTest := t.TempDir()
+		fsys := newFakeFileSystem()
 
 		// Create zombie edit files (no corresponding raw files)
 		for i := range 3 {
-			_, err := os.Create(filepath.Join(dirTest, fmt.Sprintf("photo%d.xmp", i+1)))
-			require.NoError(t, err)
+			fsys.addFile(fmt.Sprintf("photo%d.xmp", i+1), "")
 		}
 
-		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 3, count)
 
 		// Verify all zombie files are deleted
-		entries, err := os.ReadDir(dirTest)
+		entries, err := fsys.ReadDir(".")
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(entries))
 	})
 
 	t.Run("keeps edit files when corresponding raw file exists", func(t *testing.T) {
-		dirTest := t.TempDir()
+		fsys := newFakeFileSystem()
 
 		// Create edit file with corresponding raw file
-		_, err := os.Create(filepath.Join(dirTest, "photo1.xmp"))
-		require.NoError(t, err)
-		_, err = os.Create(filepath.Join(dirTest, "photo1.arw"))
-		require.NoError(t, err)
+		fsys.addFile("photo1.xmp", "")
+		fsys.addFile("photo1.arw", "")
 
 		// Create another edit file with corresponding raw file (different extension)
-		_, err = os.Create(filepath.Join(dirTest, "photo2.xmp"))
-		require.NoError(t, err)
-		_, err = os.Create(filepath.Join(dirTest, "photo2.raw"))
-		require.NoError(t, err)
+		fsys.addFile("photo2.xmp", "")
+		fsys.addFile("photo2.raw", "")
 
-		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 0, count)
 
 		// Verify all files still exist
-		entries, err := os.ReadDir(dirTest)
+		entries, err := fsys.ReadDir(".")
 		require.NoError(t, err)
 		assert.Equal(t, 4, len(entries))
 	})
 
 	t.Run("mixed scenario with some zombie and some valid edit files", func(t *testing.T) {
-		dirTest := t.TempDir()
+		fsys := newFakeFileSystem()
 
 		// Create valid edit file (has corresponding raw)
-		_, err := os.Create(filepath.Join(dirTest, "valid.xmp"))
-		require.NoError(t, err)
-		_, err = os.Create(filepath.Join(dirTest, "valid.arw"))
-		require.NoError(t, err)
+		fsys.addFile("valid.xmp", "")
+		fsys.addFile("valid.arw", "")
 
 		// Create zombie edit files (no corresponding raw)
-		_, err = os.Create(filepath.Join(dirTest, "zombie1.xmp"))
-		require.NoError(t, err)
-		_, err = os.Create(filepath.Join(dirTest, "zombie2.xmp"))
-		require.NoError(t, err)
+		fsys.addFile("zombie1.xmp", "")
+		fsys.addFile("zombie2.xmp", "")
 
-		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, count)
 
 		// Verify valid files still exist and zombies are deleted
-		entries, err := os.ReadDir(dirTest)
+		entries, err := fsys.ReadDir(".")
 		require.NoError(t, err)
 
 		fileNames := make([]string, len(entries))
@@ -160,68 +134,63 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 	})
 
 	t.Run("does not delete non-edit files", func(t *testing.T) {
-		dirTest := t.TempDir()
+		fsys := newFakeFileSystem()
 
 		// Create non-edit files
-		_, err := os.Create(filepath.Join(dirTest, "photo.jpg"))
-		require.NoError(t, err)
-		_, err = os.Create(filepath.Join(dirTest, "photo.png"))
-		require.NoError(t, err)
+		fsys.addFile("photo.jpg", "")
+		fsys.addFile("photo.png", "")
 
-		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 0, count)
 
 		// Verify files still exist
-		entries, err := os.ReadDir(dirTest)
+		entries, err := fsys.ReadDir(".")
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(entries))
 	})
 
 	t.Run("handles empty directory", func(t *testing.T) {
-		dirTest := t.TempDir()
+		fsys := newFakeFileSystem()
 
-		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 0, count)
 	})
 
 	t.Run("returns error for non-existent directory", func(t *testing.T) {
-		count, err := deleteZombieEditFiles("xmp", "/non/existent/path", []string{"arw", "raw"}, false)
+		fsys := newFakeFileSystem()
+
+		count, err := deleteZombieEditFiles(fsys, "xmp", "/non/existent/path", []string{"arw", "raw"}, false)
 
 		assert.Error(t, err)
 		assert.Equal(t, 0, count)
 	})
 
 	t.Run("recursive mode deletes zombie files in subdirectories", func(t *testing.T) {
-		dirTest := t.TempDir()
-		subDir := filepath.Join(dirTest, "subdir")
-		err := os.MkdirAll(subDir, 0755)
-		require.NoError(t, err)
+		fsys := newFakeFileSystem()
+		subDir := "subdir"
+		fsys.addDir(subDir)
 
 		// Create zombie edit file in root
-		_, err = os.Create(filepath.Join(dirTest, "root_zombie.xmp"))
-		require.NoError(t, err)
+		fsys.addFile("root_zombie.xmp", "")
 
 		// Create zombie edit file in subdirectory
-		_, err = os.Create(filepath.Join(subDir, "sub_zombie.xmp"))
-		require.NoError(t, err)
+		fsys.addFile(filepath.Join(subDir, "sub_zombie.xmp"), "")
 
 		// Create valid edit file with raw in subdirectory
-		_, err = os.Create(filepath.Join(subDir, "valid.xmp"))
-		require.NoError(t, err)
-		_, err = os.Create(filepath.Join(subDir, "valid.arw"))
-		require.NoError(t, err)
+		fsys.addFile(filepath.Join(subDir, "valid.xmp"), "")
+		fsys.addFile(filepath.Join(subDir, "valid.arw"), "")
 
-		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, true)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, true)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, count) // root_zombie.xmp + sub_zombie.xmp
 
 		// Verify valid files in subdirectory still exist
-		entries, err := os.ReadDir(subDir)
+		entries, err := fsys.ReadDir(subDir)
 		require.NoError(t, err)
 		fileNames := make([]string, len(entries))
 		for i, entry := range entries {
@@ -231,26 +200,23 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 	})
 
 	t.Run("non-recursive mode skips subdirectories", func(t *testing.T) {
-		dirTest := t.TempDir()
-		subDir := filepath.Join(dirTest, "subdir")
-		err := os.MkdirAll(subDir, 0755)
-		require.NoError(t, err)
+		fsys := newFakeFileSystem()
+		subDir := "subdir"
+		fsys.addDir(subDir)
 
 		// Create zombie edit file in root
-		_, err = os.Create(filepath.Join(dirTest, "root_zombie.xmp"))
-		require.NoError(t, err)
+		fsys.addFile("root_zombie.xmp", "")
 
 		// Create zombie edit file in subdirectory
-		_, err = os.Create(filepath.Join(subDir, "sub_zombie.xmp"))
-		require.NoError(t, err)
+		fsys.addFile(filepath.Join(subDir, "sub_zombie.xmp"), "")
 
-		count, err := deleteZombieEditFiles("xmp", dirTest, []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 1, count) // only root_zombie.xmp
 
 		// Verify subdirectory file still exists
-		entries, err := os.ReadDir(subDir)
+		entries, err := fsys.ReadDir(subDir)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(entries))
 		assert.Equal(t, "sub_zombie.xmp", entries[0].Name())
@@ -267,14 +233,14 @@ func TestCopyFilesDeadlock(t *testing.T) {
 		err := os.WriteFile(srcFilePath, []byte("hello"), 0644)
 		require.NoError(t, err)
 
-		// Create a directory in the destination with the same name as the source file
-		// This will cause os.Create(dstPath) in copyFile to fail.
+		// Create a directory in the destination with the same name as the source file.
+		// This will cause os.Create(dstPath) in osFileSystem.CopyFile to fail.
 		err = os.Mkdir(filepath.Join(dirDst, "file1.txt"), 0755)
 		require.NoError(t, err)
 
 		// This call would hang if the deadlock is present.
 		// We expect it to complete with an error.
-		count, err := copyFiles(dirSrc, dirDst, "txt", false, true)
+		count, err := copyFiles(osFileSystem{}, dirSrc, dirDst, "txt", false, true)
 
 		assert.Error(t, err)
 		assert.Equal(t, 0, count)


### PR DESCRIPTION
## Summary
- `copyFiles`, `removeFiles`, and `deleteZombieEditFiles` called `os.ReadDir`/`os.Stat`/`os.Remove`/file-copy directly, coupling the copy/cleanup policy to the real disk (a DIP violation)
- This is also the root cause of the `TestCleanSDCard`/`TestDeleteZombieEditFiles` flakiness on Windows we kept hitting in previous PRs: real files are subject to transient locks from indexers/antivirus
- Introduce a `FileSystem` interface with an `osFileSystem` implementation for production, split into `filesystem.go`
- Tests now use an in-memory `fakeFileSystem` (`fake_filesystem_test.go`) instead of real temp directories, removing the OS dependency entirely. Ran `go test -count=1` 5 times in a row with zero flakes (previously flaky every run)
- `TestCopyFilesDeadlock` keeps using the real `osFileSystem` since it specifically exercises a real-disk failure mode (a directory blocking file creation)
- Fixes the package doc's `go run main.go` example and the same pattern in README.md — both broke once symbols moved into `filesystem.go`, since a single-file `go run` no longer builds the whole package
- Stacked on #9 (explicit JPG destination dir); diff here is scoped to this abstraction only

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./... x5 consecutive runs, all pass with zero flakes
- [x] Manually verified `go run . -dry-run` works after the file split