### PR TITLE
Perf: read the source directory once instead of once per extension

### DIFF
--- a/fake_filesystem_test.go
+++ b/fake_filesystem_test.go
@@ -181,3 +181,28 @@ func (i fakeFileInfo) Mode() fs.FileMode {
 func (i fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (i fakeFileInfo) IsDir() bool        { return i.isDir }
 func (i fakeFileInfo) Sys() any           { return nil }
+
+// readDirCountingFileSystem wraps a FileSystem and counts ReadDir calls per
+// directory, so tests can assert a directory isn't listed more than once.
+type readDirCountingFileSystem struct {
+	FileSystem
+	mu           sync.Mutex
+	readDirCalls map[string]int
+}
+
+func newReadDirCountingFileSystem(fsys FileSystem) *readDirCountingFileSystem {
+	return &readDirCountingFileSystem{FileSystem: fsys, readDirCalls: make(map[string]int)}
+}
+
+func (f *readDirCountingFileSystem) ReadDir(dir string) ([]os.DirEntry, error) {
+	f.mu.Lock()
+	f.readDirCalls[dir]++
+	f.mu.Unlock()
+	return f.FileSystem.ReadDir(dir)
+}
+
+func (f *readDirCountingFileSystem) callsFor(dir string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.readDirCalls[dir]
+}

--- a/filesystem.go
+++ b/filesystem.go
@@ -97,23 +97,33 @@ func forEachEntryConcurrently(entries []os.DirEntry, fn func(entry os.DirEntry) 
 	return int(count.Load()), errs
 }
 
-// copyFiles copies files with the given extension from srcDir to dstDir.
+// matchesAnyExtension reports whether name has one of exts as its extension.
+func matchesAnyExtension(name string, exts []string) bool {
+	nameExt := filepath.Ext(name)
+	for _, ext := range exts {
+		if strings.EqualFold(nameExt, "."+ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// copyFiles copies entries whose extension is in exts from srcDir to dstDir.
+// entries is a directory listing of srcDir supplied by the caller so that a
+// single srcDir listing can be shared across multiple extension groups
+// instead of re-reading the (potentially slow, e.g. SD card) source directory
+// once per group.
 // If flagDryRun is true, it counts files without copying.
 // If flagOverwrite is true, it overwrites existing files in dstDir.
 // It returns the number of files copied and any error.
-func copyFiles(fsys FileSystem, srcDir, dstDir, ext string, flagDryRun, flagOverwrite bool) (int, error) {
-	entries, err := fsys.ReadDir(srcDir)
-	if err != nil {
-		return 0, err
-	}
-
+func copyFiles(fsys FileSystem, entries []os.DirEntry, srcDir, dstDir string, exts []string, flagDryRun, flagOverwrite bool) (int, error) {
 	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
 		if entry.IsDir() {
 			return 0, nil
 		}
 
 		name := entry.Name()
-		if !strings.EqualFold(filepath.Ext(name), "."+ext) {
+		if !matchesAnyExtension(name, exts) {
 			return 0, nil
 		}
 
@@ -141,14 +151,10 @@ func copyFiles(fsys FileSystem, srcDir, dstDir, ext string, flagDryRun, flagOver
 	})
 }
 
-// removeFiles removes all files in the directory.
+// removeFiles removes all files in entries, a directory listing of dir
+// supplied by the caller (see copyFiles).
 // It returns the number of files removed and any error.
-func removeFiles(fsys FileSystem, dir string) (int, error) {
-	entries, err := fsys.ReadDir(dir)
-	if err != nil {
-		return 0, err
-	}
-
+func removeFiles(fsys FileSystem, entries []os.DirEntry, dir string) (int, error) {
 	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
 		if entry.IsDir() {
 			return 0, nil

--- a/main.go
+++ b/main.go
@@ -91,25 +91,26 @@ func cleanSDCard(
 		}
 	}
 
+	// List dirSrc once and reuse it for the raw copy, JPG copy, and removal
+	// steps below, instead of re-reading it once per extension group. dirSrc
+	// is typically a slow SD card, so this avoids redundant directory reads
+	// against it.
+	entries, err := fsys.ReadDir(dirSrc)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read source directory: %w", err)
+	}
+
 	// copy raw files
-	totalCopied := 0
-	for _, ext := range extensionsToCopy {
-		n, err := copyFiles(fsys, dirSrc, dirDst, ext, opts.DryRun, opts.Overwrite)
-		if err != nil {
-			return totalCopied, 0, fmt.Errorf("failed to copy .%s files (copied %d): %w", ext, n, err)
-		}
-		totalCopied += n
+	totalCopied, err := copyFiles(fsys, entries, dirSrc, dirDst, extensionsToCopy, opts.DryRun, opts.Overwrite)
+	if err != nil {
+		return totalCopied, 0, fmt.Errorf("failed to copy files with extensions %v (copied %d): %w", extensionsToCopy, totalCopied, err)
 	}
 
 	// copy jpg
 	if opts.KeepJPG {
-		var countJPGToCopy int
-		for _, ext := range extensionsJPG {
-			n, err := copyFiles(fsys, dirSrc, dirDstJPG, ext, opts.DryRun, opts.Overwrite)
-			if err != nil {
-				return 0, 0, fmt.Errorf("failed to copy .%s files to %s (copied %d): %w", ext, dirDstJPG, n, err)
-			}
-			countJPGToCopy += n
+		countJPGToCopy, err := copyFiles(fsys, entries, dirSrc, dirDstJPG, extensionsJPG, opts.DryRun, opts.Overwrite)
+		if err != nil {
+			return totalCopied, 0, fmt.Errorf("failed to copy JPG files to %s (copied %d): %w", dirDstJPG, countJPGToCopy, err)
 		}
 		if opts.DryRun {
 			log.Printf("[dry-run] would copy %d JPG files\n", countJPGToCopy)
@@ -122,8 +123,7 @@ func cleanSDCard(
 	// remove source files
 	removedCount := 0
 	if !opts.DryRun && !opts.KeepSrc {
-		var err error
-		removedCount, err = removeFiles(fsys, dirSrc)
+		removedCount, err = removeFiles(fsys, entries, dirSrc)
 		if err != nil {
 			return totalCopied, removedCount, fmt.Errorf("failed to remove source files: %w", err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -64,6 +64,33 @@ func TestCleanSDCard(t *testing.T) {
 	assert.Equal(t, 0, len(entries))
 }
 
+func TestCleanSDCardReadsSourceDirOnce(t *testing.T) {
+	fake := newFakeFileSystem()
+	dirSrc := "src"
+	dirDst := "dst"
+	dirDstJPG := "dst-jpg"
+
+	fake.addFile(filepath.Join(dirSrc, "photo1.raw"), "content")
+	fake.addFile(filepath.Join(dirSrc, "photo2.arw"), "content")
+	fake.addFile(filepath.Join(dirSrc, "photo3.jpg"), "content")
+
+	counting := newReadDirCountingFileSystem(fake)
+
+	_, _, err := cleanSDCard(
+		counting,
+		[]string{"xmp"},
+		[]string{"raw", "arw"},
+		[]string{"jpg", "jpeg"},
+		dirSrc,
+		dirDst,
+		dirDstJPG,
+		Options{KeepJPG: true, DeleteZombieEditFiles: false},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, counting.callsFor(dirSrc), "dirSrc should only be listed once, shared across the raw copy, JPG copy, and removal steps")
+}
+
 func TestDeleteZombieEditFiles(t *testing.T) {
 	t.Run("deletes zombie edit files when no corresponding raw file exists", func(t *testing.T) {
 		fsys := newFakeFileSystem()
@@ -238,9 +265,13 @@ func TestCopyFilesDeadlock(t *testing.T) {
 		err = os.Mkdir(filepath.Join(dirDst, "file1.txt"), 0755)
 		require.NoError(t, err)
 
+		fsys := osFileSystem{}
+		entries, err := fsys.ReadDir(dirSrc)
+		require.NoError(t, err)
+
 		// This call would hang if the deadlock is present.
 		// We expect it to complete with an error.
-		count, err := copyFiles(osFileSystem{}, dirSrc, dirDst, "txt", false, true)
+		count, err := copyFiles(fsys, entries, dirSrc, dirDst, []string{"txt"}, false, true)
 
 		assert.Error(t, err)
 		assert.Equal(t, 0, count)


### PR DESCRIPTION
## Summary
- You mentioned the SD card read speed feels like the bottleneck. One concrete, low-risk win: `cleanSDCard` was listing `dirSrc` up to 5 times per run — once per extension in `extensionsToCopy` (2), once per extension in `extensionsJPG` (2), and once more in `removeFiles` — all against the same, typically-slow SD card.
- List `dirSrc` once in `cleanSDCard` and share the `[]os.DirEntry` across the raw copy, JPG copy, and removal steps. `copyFiles` now takes a list of extensions (`matchesAnyExtension`) instead of being called once per extension, so a single listing covers a whole group.
- Added `TestCleanSDCardReadsSourceDirOnce` with a new `readDirCountingFileSystem` test wrapper to pin this down: `dirSrc` is listed exactly once even with both raw and JPG groups enabled.
- Left concurrency (one goroutine per file) as-is — since the SD card is a single physical read channel, more concurrency doesn't necessarily help and could hurt (random access vs sequential); that needs real measurement before touching, so out of scope here.

## Self-review note
Restructuring the JPG-copy error path incidentally fixes an existing bug: previously, if the JPG copy step failed, `cleanSDCard` returned `totalCopied=0`, discarding the count from the already-succeeded raw copy. The rewrite naturally preserves `totalCopied` in that error path instead — a correctness improvement, not something intentionally targeted.

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./... x3 consecutive runs, all pass
- [x] New test proves dirSrc is read exactly once (previously up to 5 times for raw+jpg+removal)