### PR TITLE
Perf: bound copy/remove concurrency instead of one goroutine per file

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -68,15 +68,25 @@ func (e fileCopyError) Error() string {
 	return fmt.Sprintf("failed to copy file %s: %s", e.fileName, e.err.Error())
 }
 
-// forEachEntryConcurrently runs fn concurrently for each entry, aggregating
-// the increments fn reports and any errors it returns.
-func forEachEntryConcurrently(entries []os.DirEntry, fn func(entry os.DirEntry) (int, error)) (int, error) {
+// forEachEntryConcurrently runs fn for each entry, aggregating the increments
+// fn reports and any errors it returns. At most maxConcurrency invocations of
+// fn run at once (values <= 0 are treated as 1), so callers touching a
+// bottlenecked device (e.g. an SD card) can bound how many concurrent
+// operations hit it instead of spawning one goroutine per entry.
+func forEachEntryConcurrently(entries []os.DirEntry, maxConcurrency int, fn func(entry os.DirEntry) (int, error)) (int, error) {
+	if maxConcurrency <= 0 {
+		maxConcurrency = 1
+	}
+
 	var count atomic.Int32
 	var wg sync.WaitGroup
 	errsChan := make(chan error, len(entries))
+	sem := make(chan struct{}, maxConcurrency)
 
 	for _, entry := range entries {
+		sem <- struct{}{}
 		wg.Go(func() {
+			defer func() { <-sem }()
 			n, err := fn(entry)
 			if err != nil {
 				errsChan <- err
@@ -112,12 +122,12 @@ func matchesAnyExtension(name string, exts []string) bool {
 // entries is a directory listing of srcDir supplied by the caller so that a
 // single srcDir listing can be shared across multiple extension groups
 // instead of re-reading the (potentially slow, e.g. SD card) source directory
-// once per group.
+// once per group. At most maxConcurrency files are copied at once.
 // If flagDryRun is true, it counts files without copying.
 // If flagOverwrite is true, it overwrites existing files in dstDir.
 // It returns the number of files copied and any error.
-func copyFiles(fsys FileSystem, entries []os.DirEntry, srcDir, dstDir string, exts []string, flagDryRun, flagOverwrite bool) (int, error) {
-	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
+func copyFiles(fsys FileSystem, entries []os.DirEntry, srcDir, dstDir string, exts []string, flagDryRun, flagOverwrite bool, maxConcurrency int) (int, error) {
+	return forEachEntryConcurrently(entries, maxConcurrency, func(entry os.DirEntry) (int, error) {
 		if entry.IsDir() {
 			return 0, nil
 		}
@@ -152,10 +162,11 @@ func copyFiles(fsys FileSystem, entries []os.DirEntry, srcDir, dstDir string, ex
 }
 
 // removeFiles removes all files in entries, a directory listing of dir
-// supplied by the caller (see copyFiles).
+// supplied by the caller (see copyFiles). At most maxConcurrency files are
+// removed at once.
 // It returns the number of files removed and any error.
-func removeFiles(fsys FileSystem, entries []os.DirEntry, dir string) (int, error) {
-	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
+func removeFiles(fsys FileSystem, entries []os.DirEntry, dir string, maxConcurrency int) (int, error) {
+	return forEachEntryConcurrently(entries, maxConcurrency, func(entry os.DirEntry) (int, error) {
 		if entry.IsDir() {
 			return 0, nil
 		}
@@ -171,20 +182,21 @@ func removeFiles(fsys FileSystem, entries []os.DirEntry, dir string) (int, error
 
 // deleteZombieEditFiles deletes edit files that have no corresponding raw file.
 // It checks for raw files with extensions in rawFileExtensions.
-// If isRecursive is true, it processes subdirectories recursively.
+// If isRecursive is true, it processes subdirectories recursively. At most
+// maxConcurrency entries are processed at once per directory level.
 // It returns the number of files deleted and any error.
-func deleteZombieEditFiles(fsys FileSystem, editFileExtension, dir string, rawFileExtensions []string, isRecursive bool) (int, error) {
+func deleteZombieEditFiles(fsys FileSystem, editFileExtension, dir string, rawFileExtensions []string, isRecursive bool, maxConcurrency int) (int, error) {
 	entries, err := fsys.ReadDir(dir)
 	if err != nil {
 		return 0, fmt.Errorf("reading directory: %w", err)
 	}
 
-	return forEachEntryConcurrently(entries, func(entry os.DirEntry) (int, error) {
+	return forEachEntryConcurrently(entries, maxConcurrency, func(entry os.DirEntry) (int, error) {
 		if entry.IsDir() {
 			if !isRecursive {
 				return 0, nil
 			}
-			n, err := deleteZombieEditFiles(fsys, editFileExtension, filepath.Join(dir, entry.Name()), rawFileExtensions, isRecursive)
+			n, err := deleteZombieEditFiles(fsys, editFileExtension, filepath.Join(dir, entry.Name()), rawFileExtensions, isRecursive, maxConcurrency)
 			if err != nil {
 				return 0, fmt.Errorf("failed to process subdirectory %s: %w", entry.Name(), err)
 			}

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForEachEntryConcurrentlyBoundsConcurrency(t *testing.T) {
+	const maxConcurrency = 3
+	const entryCount = 20
+
+	entries := make([]os.DirEntry, entryCount)
+	for i := range entries {
+		entries[i] = fakeDirEntry{name: fmt.Sprintf("file%d", i)}
+	}
+
+	var current atomic.Int32
+	var maxObserved atomic.Int32
+
+	_, err := forEachEntryConcurrently(entries, maxConcurrency, func(entry os.DirEntry) (int, error) {
+		n := current.Add(1)
+		defer current.Add(-1)
+
+		for {
+			observed := maxObserved.Load()
+			if n <= observed || maxObserved.CompareAndSwap(observed, n) {
+				break
+			}
+		}
+
+		// Give other goroutines a chance to overlap so the bound is
+		// actually exercised, not just trivially satisfied.
+		time.Sleep(5 * time.Millisecond)
+		return 1, nil
+	})
+
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, int(maxObserved.Load()), maxConcurrency, "concurrency exceeded the configured limit")
+	assert.Equal(t, int32(maxConcurrency), maxObserved.Load(), "expected concurrency to actually reach the configured limit, not stay needlessly under it")
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,13 @@ const (
 	defaultDirDst = "D:\\raw"
 
 	defaultDirDstJPG = "D:\\jpeg"
+
+	// defaultConcurrency caps how many files are copied/removed at once.
+	// dirSrc is typically an SD card behind a single physical read channel,
+	// so unbounded per-file concurrency doesn't help throughput and can hurt
+	// it (more random access, more scheduling overhead). This is a starting
+	// point, not a measured optimum -- tune with -concurrency.
+	defaultConcurrency = 4
 )
 
 // Options holds the flags that control cleanSDCard's behavior.
@@ -26,6 +33,7 @@ type Options struct {
 	KeepSrc               bool
 	Overwrite             bool
 	DeleteZombieEditFiles bool
+	Concurrency           int
 }
 
 func main() {
@@ -42,6 +50,7 @@ func main() {
 	flag.BoolVar(&opts.KeepJPG, "keep-jpg", true, "Keep JPG files in destination (default: true)")
 	flag.BoolVar(&opts.KeepSrc, "keep-src", false, "Keep files in the source (SD card) directory after copying instead of removing them (default: false)")
 	flag.BoolVar(&opts.DeleteZombieEditFiles, "delete-zombie-edit-files", true, "Delete zombie edit files (default: true)")
+	flag.IntVar(&opts.Concurrency, "concurrency", defaultConcurrency, "Maximum number of files to copy/remove concurrently (default: 4). Tune based on your card reader's actual throughput.")
 	flag.StringVar(&dirSrc, "src", defaultDirSrc, "Source directory")
 	flag.StringVar(&dirDst, "dst", defaultDirDst, "Destination directory")
 	flag.StringVar(&dirDstJPG, "dst-jpg", defaultDirDstJPG, "Destination directory for JPG files")
@@ -101,14 +110,14 @@ func cleanSDCard(
 	}
 
 	// copy raw files
-	totalCopied, err := copyFiles(fsys, entries, dirSrc, dirDst, extensionsToCopy, opts.DryRun, opts.Overwrite)
+	totalCopied, err := copyFiles(fsys, entries, dirSrc, dirDst, extensionsToCopy, opts.DryRun, opts.Overwrite, opts.Concurrency)
 	if err != nil {
 		return totalCopied, 0, fmt.Errorf("failed to copy files with extensions %v (copied %d): %w", extensionsToCopy, totalCopied, err)
 	}
 
 	// copy jpg
 	if opts.KeepJPG {
-		countJPGToCopy, err := copyFiles(fsys, entries, dirSrc, dirDstJPG, extensionsJPG, opts.DryRun, opts.Overwrite)
+		countJPGToCopy, err := copyFiles(fsys, entries, dirSrc, dirDstJPG, extensionsJPG, opts.DryRun, opts.Overwrite, opts.Concurrency)
 		if err != nil {
 			return totalCopied, 0, fmt.Errorf("failed to copy JPG files to %s (copied %d): %w", dirDstJPG, countJPGToCopy, err)
 		}
@@ -123,7 +132,7 @@ func cleanSDCard(
 	// remove source files
 	removedCount := 0
 	if !opts.DryRun && !opts.KeepSrc {
-		removedCount, err = removeFiles(fsys, entries, dirSrc)
+		removedCount, err = removeFiles(fsys, entries, dirSrc, opts.Concurrency)
 		if err != nil {
 			return totalCopied, removedCount, fmt.Errorf("failed to remove source files: %w", err)
 		}
@@ -132,7 +141,7 @@ func cleanSDCard(
 	// delete zombie edit files
 	if !opts.DryRun && opts.DeleteZombieEditFiles {
 		for _, editFileExtension := range editFileExtensions {
-			count, err := deleteZombieEditFiles(fsys, editFileExtension, dirDst, extensionsToCopy, true)
+			count, err := deleteZombieEditFiles(fsys, editFileExtension, dirDst, extensionsToCopy, true, opts.Concurrency)
 			if err != nil {
 				return totalCopied, removedCount, fmt.Errorf("failed to delete zombie edit files with extension %s: %w", editFileExtension, err)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testConcurrency = 4
+
 func TestCleanSDCard(t *testing.T) {
 	fsys := newFakeFileSystem()
 	dirSrc := "src"
@@ -24,6 +26,7 @@ func TestCleanSDCard(t *testing.T) {
 		DeleteZombieEditFiles: false,
 		KeepJPG:               false,
 		KeepSrc:               false,
+		Concurrency:           testConcurrency,
 	}
 
 	fileCount := 30
@@ -84,7 +87,7 @@ func TestCleanSDCardReadsSourceDirOnce(t *testing.T) {
 		dirSrc,
 		dirDst,
 		dirDstJPG,
-		Options{KeepJPG: true, DeleteZombieEditFiles: false},
+		Options{KeepJPG: true, DeleteZombieEditFiles: false, Concurrency: testConcurrency},
 	)
 
 	assert.NoError(t, err)
@@ -100,7 +103,7 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 			fsys.addFile(fmt.Sprintf("photo%d.xmp", i+1), "")
 		}
 
-		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false, testConcurrency)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 3, count)
@@ -122,7 +125,7 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 		fsys.addFile("photo2.xmp", "")
 		fsys.addFile("photo2.raw", "")
 
-		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false, testConcurrency)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 0, count)
@@ -144,7 +147,7 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 		fsys.addFile("zombie1.xmp", "")
 		fsys.addFile("zombie2.xmp", "")
 
-		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false, testConcurrency)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, count)
@@ -167,7 +170,7 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 		fsys.addFile("photo.jpg", "")
 		fsys.addFile("photo.png", "")
 
-		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false, testConcurrency)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 0, count)
@@ -181,7 +184,7 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 	t.Run("handles empty directory", func(t *testing.T) {
 		fsys := newFakeFileSystem()
 
-		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false, testConcurrency)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 0, count)
@@ -190,7 +193,7 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 	t.Run("returns error for non-existent directory", func(t *testing.T) {
 		fsys := newFakeFileSystem()
 
-		count, err := deleteZombieEditFiles(fsys, "xmp", "/non/existent/path", []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", "/non/existent/path", []string{"arw", "raw"}, false, testConcurrency)
 
 		assert.Error(t, err)
 		assert.Equal(t, 0, count)
@@ -211,7 +214,7 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 		fsys.addFile(filepath.Join(subDir, "valid.xmp"), "")
 		fsys.addFile(filepath.Join(subDir, "valid.arw"), "")
 
-		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, true)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, true, testConcurrency)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, count) // root_zombie.xmp + sub_zombie.xmp
@@ -237,7 +240,7 @@ func TestDeleteZombieEditFiles(t *testing.T) {
 		// Create zombie edit file in subdirectory
 		fsys.addFile(filepath.Join(subDir, "sub_zombie.xmp"), "")
 
-		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false)
+		count, err := deleteZombieEditFiles(fsys, "xmp", ".", []string{"arw", "raw"}, false, testConcurrency)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 1, count) // only root_zombie.xmp
@@ -271,7 +274,7 @@ func TestCopyFilesDeadlock(t *testing.T) {
 
 		// This call would hang if the deadlock is present.
 		// We expect it to complete with an error.
-		count, err := copyFiles(fsys, entries, dirSrc, dirDst, []string{"txt"}, false, true)
+		count, err := copyFiles(fsys, entries, dirSrc, dirDst, []string{"txt"}, false, true, testConcurrency)
 
 		assert.Error(t, err)
 		assert.Equal(t, 0, count)


### PR DESCRIPTION
## Summary
- Following up on the SD-card-bottleneck discussion: `forEachEntryConcurrently` spawned one goroutine per directory entry with no limit, so e.g. 1000 files on an SD card would fire off 1000 simultaneous reads/writes against a single physical read channel. That doesn't increase throughput and can hurt it (more random access, more scheduling overhead) since the actual bottleneck is the card itself, not CPU/write-side concurrency.
- Add a semaphore bound (`maxConcurrency`) to `forEachEntryConcurrently`, threaded through `copyFiles`/`removeFiles`/`deleteZombieEditFiles` via a new `Options.Concurrency` field and a `-concurrency` flag (default `4`).
- The default of 4 is a starting point, not a measured optimum for any specific card/reader — tune it with `-concurrency` and compare against the previous unbounded behavior on your actual hardware.
- Added `TestForEachEntryConcurrentlyBoundsConcurrency`, which tracks the actual in-flight goroutine count and asserts it never exceeds the configured limit (and does reach it, so the test isn't trivially satisfied by under-using concurrency).
- Stacked on #11 (single source directory read); diff here is scoped to this concurrency bound only

## Known limitation (self-review)
`deleteZombieEditFiles` recurses into subdirectories, and each recursive call creates its own independent semaphore via `forEachEntryConcurrently`, so deeply nested directories can compound total concurrency beyond the configured limit. This only affects `dirDst` (the local destination), not `dirSrc` (the SD card this feature targets), so left as-is — flagging for visibility rather than fixing out of scope.

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./... x3 consecutive runs, all pass
- [x] New test proves concurrency is bounded and actually reaches the configured limit