### PR TITLE
Change default behavior to keep source files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A simple Go utility designed to offload RAW image files from an SD card to a loc
 
 ## Description
 
-This tool scans a source directory for files with `.arw` or `.raw` extensions. It copies them to a destination directory and then removes **all** files from the source directory to free up space.
+This tool scans a source directory for files with `.arw` or `.raw` extensions and copies them to a destination directory. By default, files in the source directory are left untouched; pass `-keep-src=false` to remove them from the source directory after copying, to free up space.
 
 ## Features
 
 - **Copy:** Safely copies `.arw` and `.raw` files to the destination.
-- **Clean:** Removes all files from the source directory after processing.
+- **Clean (opt-in):** Removes all files from the source directory after processing when `-keep-src=false` is passed.
 - **Zombie Edit File Cleanup:** Automatically removes orphaned `.xmp` edit files (Lightroom sidecar files) that no longer have a corresponding RAW file.
 - **Dry Run:** Simulate the process to see what would happen without making actual changes.
 - **Overwrite Control:** Option to overwrite existing files in the destination.
@@ -34,6 +34,7 @@ go run . [flags]
 - `-dst`: Destination directory (default: `D:\raw`).
 - `-dry-run`: Simulate operations without modifying any files. Useful for verification.
 - `-overwrite`: Overwrite existing files in the destination directory. Default behavior skips existing files.
+- `-keep-src`: Keep files in the source (SD card) directory after copying instead of removing them (default: `true`). Pass `-keep-src=false` to remove source files after a successful copy.
 - `-delete-zombie-edit-files`: Delete orphaned `.xmp` edit files that have no corresponding RAW file (default: `true`).
 
 ### Examples
@@ -45,7 +46,7 @@ go run . -dry-run
 ```
 
 **2. Standard Run**
-Copy files and clean the SD card (skips existing files in destination):
+Copy files, leaving the SD card untouched (skips existing files in destination):
 ```bash
 go run .
 ```
@@ -62,7 +63,13 @@ Specify custom directories:
 go run . -src /path/to/sd/card -dst /path/to/backup
 ```
 
-**5. Skip Zombie Edit File Cleanup**
+**5. Clean the SD Card**
+Copy files and then remove them from the source directory to free up space:
+```bash
+go run . -keep-src=false
+```
+
+**6. Skip Zombie Edit File Cleanup**
 Keep orphaned `.xmp` files in the destination:
 ```bash
 go run . -delete-zombie-edit-files=false

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	flag.BoolVar(&opts.DryRun, "dry-run", false, "Simulate operations without modifying files (default: false)")
 	flag.BoolVar(&opts.Overwrite, "overwrite", false, "Overwrite existing files in destination (default: false)")
 	flag.BoolVar(&opts.KeepJPG, "keep-jpg", true, "Keep JPG files in destination (default: true)")
-	flag.BoolVar(&opts.KeepSrc, "keep-src", false, "Keep files in the source (SD card) directory after copying instead of removing them (default: false)")
+	flag.BoolVar(&opts.KeepSrc, "keep-src", true, "Keep files in the source (SD card) directory after copying instead of removing them (default: true)")
 	flag.BoolVar(&opts.DeleteZombieEditFiles, "delete-zombie-edit-files", true, "Delete zombie edit files (default: true)")
 	flag.IntVar(&opts.Concurrency, "concurrency", defaultConcurrency, "Maximum number of files to copy/remove concurrently (default: 4). Tune based on your card reader's actual throughput.")
 	flag.StringVar(&dirSrc, "src", defaultDirSrc, "Source directory")
@@ -67,6 +67,8 @@ func main() {
 	}
 	if opts.KeepSrc {
 		log.Println("Running in Keep-Src mode. Files in the source directory will not be removed.")
+	} else {
+		log.Println("Keep-Src mode disabled. Files in the source directory will be removed after copying.")
 	}
 
 	totalCopied, removedCount, err := cleanSDCard(


### PR DESCRIPTION
## Summary
This PR changes the default behavior of the tool from destructively removing source files to safely keeping them. Users must now explicitly opt-in to source file removal with `-keep-src=false`, making the tool safer by default.

## Key Changes
- **Default behavior flip:** Changed `-keep-src` flag default from `false` to `true`, so source files are preserved after copying by default
- **Updated documentation:** Revised README to reflect the new safe-by-default behavior and clarify that file removal is now opt-in
- **Enhanced logging:** Added explicit log message when Keep-Src mode is disabled to inform users that source files will be removed
- **Improved examples:** Added new example demonstrating how to clean the SD card with `-keep-src=false`

## Implementation Details
- The flag definition in `main.go` now defaults to `true` instead of `false`
- Added conditional logging to clearly communicate when the tool will remove source files
- Documentation now emphasizes that the default behavior leaves the SD card untouched, with removal being an explicit opt-in operation via `-keep-src=false`
- This change prioritizes data safety by preventing accidental data loss while still supporting the cleanup use case for users who need it

https://claude.ai/code/session_01QQe4k1vZhx1nLpynfFPYrM